### PR TITLE
Catch reminder error if reminder sending fails

### DIFF
--- a/app/services/send_reminder.rb
+++ b/app/services/send_reminder.rb
@@ -12,7 +12,7 @@ class SendReminder
       send_sms_reminder if @reminder.sms?
       send_slack_reminder if @reminder.slack?
     rescue => e
-      error_send_reminder(e)
+      reminder_error_notification(e)
       set_reminder_tomorrow
     end
     # TODO: Log reminders sent
@@ -41,8 +41,8 @@ class SendReminder
     message = @client.api.account.messages.create( from: from_number, to: to_number, body: message_body )
   end
 
-  def error_send_reminder(e)
-    SlackService.new.error_send_reminder(@reminder, e).deliver
+  def reminder_error_notification(e)
+    SlackService.new.send_reminder_error(@reminder, e).deliver
   end
 
   def set_next_reminder

--- a/app/services/slack_service.rb
+++ b/app/services/slack_service.rb
@@ -163,13 +163,13 @@ class SlackService
     self
   end
 
-  def error_send_reminder(reminder, error)
+  def send_reminder_error(reminder, error)
     params = {
       attachments: [
         {
-          title: 'Can not send a reminder',
+          title: 'Error sending reminder',
           color: WARNING,
-          fallback: 'Error send a reminder ID ' + reminder.id.to_s,
+          fallback: 'Error sending reminder ID ' + reminder.id.to_s,
           fields: [
             {
               title: 'Reminder ID',


### PR DESCRIPTION
- Catch reminder error if any reminder sending fails
- If any send reminder fails, send the error message to slack