### PR TITLE
Go back to document show page after edit document

### DIFF
--- a/app/controllers/symphony/documents_controller.rb
+++ b/app/controllers/symphony/documents_controller.rb
@@ -25,8 +25,7 @@ class Symphony::DocumentsController < DocumentsController
 
   def update
     if @document.update(document_params)
-      flash[:notice] = 'Document was successfully updated.'
-      render :show
+      redirect_to symphony_document_path, notice: 'Document was successfully updated.'
     else
       set_templates
       render :edit


### PR DESCRIPTION
- Change `redirect_to` to `render` for go back to document show page after edit document.