### PR TITLE
404 not found for tempusdominus-bootstrap-4.css

### DIFF
--- a/app/assets/stylesheets/application-dashboard.scss
+++ b/app/assets/stylesheets/application-dashboard.scss
@@ -20,7 +20,7 @@
 @import "bootstrap";
 @import "themify-icons";
 @import "font-awesome";
-@import "tempusdominus-bootstrap-4.css";
+@import "tempusdominus-bootstrap-4";
 @import "simple_calendar";
 @import "conductor/availabilities";
 @import "conductor/home";


### PR DESCRIPTION
- Remove file extension of `tempusdominus-bootstrap-4.css` 