### PR TITLE
Navigation bar excide homepage on mobile

### DIFF
--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -7,7 +7,7 @@ nav
         img.logo.logo-dark alt="Foundry" src=image_url('excide-logo.png')
     .module.widget-handle.mobile-toggle.right.d-xl-none
       i.ti-menu
-    .module-group.right.d-none.d-xl-block
+    .module-group.right.d-xl-block
       .module.left
         - if current_user
           ul.menu


### PR DESCRIPTION
- Remove .d-none class to fix show menu on mobile