### PR TITLE
Fix alignment of line-item code

### DIFF
--- a/app/views/symphony/invoices/_line_items.html.slim
+++ b/app/views/symphony/invoices/_line_items.html.slim
@@ -2,12 +2,12 @@ tr.line_items
 	td.line-item-field = f.text_field :description, class: 'form-control minimize-text'
 	td.line-item-field = f.text_field :quantity, class: 'form-control minimize-text'
 	td.line-item-field = f.text_field :price, class: 'form-control minimize-text'
-  td.line-item-field = f.collection_select :account, @full_account_code, :to_s, :to_s, { include_blank: 'Account code...' }, { class: 'minimize-text dropdown-overlay line-items-dropdown-width' }
-  td.line-item-field.tax = f.collection_select :tax, @full_tax_code, :to_s, :to_s, { include_blank: 'Tax code...' }, { class: 'minimize-text dropdown-overlay line-items-dropdown-width' }
-  - if @tracking_categories_2.present?
-    td.line-item-field = f.collection_select :tracking_option_1, @tracking_categories_1, :name, ->(option){ option.name }, { include_blank: '(None)' }, { class: 'minimize-text dropdown-overlay line-items-dropdown-width' }
-    td.line-item-field = f.collection_select :tracking_option_2, @tracking_categories_2, :name, ->(option){ option.name }, { include_blank: '(None)' }, { class: 'minimize-text dropdown-overlay line-items-dropdown-width' }
-  - elsif @tracking_categories_1.present? and @tracking_categories_2.nil?
-    td.line-item-field = f.collection_select :tracking_option_1, @tracking_categories_1, :name, ->(option){ option.name }, { include_blank: '(None)' }, { class:  'minimize-text dropdown-overlay line-items-dropdown-width' }
+	td.line-item-field = f.collection_select :account, @full_account_code, :to_s, :to_s, { include_blank: 'Account code...' }, { class: 'minimize-text dropdown-overlay line-items-dropdown-width' }
+	td.line-item-field.tax = f.collection_select :tax, @full_tax_code, :to_s, :to_s, { include_blank: 'Tax code...' }, { class: 'minimize-text dropdown-overlay line-items-dropdown-width' }
+	- if @tracking_categories_2.present?
+		td.line-item-field = f.collection_select :tracking_option_1, @tracking_categories_1, :name, ->(option){ option.name }, { include_blank: '(None)' }, { class: 'minimize-text dropdown-overlay line-items-dropdown-width' }
+		td.line-item-field = f.collection_select :tracking_option_2, @tracking_categories_2, :name, ->(option){ option.name }, { include_blank: '(None)' }, { class: 'minimize-text dropdown-overlay line-items-dropdown-width' }
+	- elsif @tracking_categories_1.present? and @tracking_categories_2.nil?
+		td.line-item-field = f.collection_select :tracking_option_1, @tracking_categories_1, :name, ->(option){ option.name }, { include_blank: '(None)' }, { class:  'minimize-text dropdown-overlay line-items-dropdown-width' }
 	td.line-item-field.pr-2 = link_to "x", '#', class: 'btn btn-danger remove_line_items'
 	= f.hidden_field :_destroy, class: 'destroy'


### PR DESCRIPTION
# Description

Alignment went off for the line-item file, leading to NOT able to access the "create invoice payable" page.

Trello link: https://trello.com/c/{card-id}

## Remarks

Sublime Text keeps coming back to tab.

# Testing

- Tested creating invoice payable, and able to view the form

## Checklist:

- [ ] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
