### PR TITLE
Change model callback to see if it fix error

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -16,7 +16,7 @@ class Workflow < ApplicationRecord
   validates :identifier, uniqueness: true
   validate :check_data_fields
 
-  after_create :create_actions_and_trigger_first_task
+  after_commit :create_actions_and_trigger_first_task, on: :create
   before_save :uppercase_identifier
 
   include PublicActivity::Model


### PR DESCRIPTION
# Description
Fix error "ActiveJob::DeserializationError: Error while trying to deserialize arguments: Couldn't find WorkflowAction"
Error might be due to WorkflowAction not being found, which cause the mailer to give back an error. 
After checking, the error was found to occur randomly (not consistent in every workflow) -> might be due to trigger_first_task called before the create action of workflow actions.
Hence, solution is to change after_create callback method to after_commit. In the case of after_create, this will always be before the call to save (or create) returns. With after_commit, the code doesn't run until it is fully created. 
stackoverflow: https://stackoverflow.com/questions/15746362/after-create-foo-vs-after-commit-bar-on-create

## Remarks

Need to test whether the error will still occur.

# Testing
- Pulled database from Heroku to test on local, with same scenarios, workflow and user's role
- Tested that mailer works through mailcatcher, with the creation of workflow and toggle next task
- Try to delete workflow action & task to check for similar error when toggling the task, but to no avail
 
## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
