### PR TITLE
Only show the outstanding workflow from current company

### DIFF
--- a/app/controllers/symphony/home_controller.rb
+++ b/app/controllers/symphony/home_controller.rb
@@ -19,7 +19,7 @@ class Symphony::HomeController < ApplicationController
     end
 
     @workflows = Kaminari.paginate_array(@templates_type).page(params[:page]).per(10)
-    @outstanding_actions = WorkflowAction.includes(workflow: [:template]).all_user_actions(current_user).where.not(completed: true).where.not(deadline: nil).order(:deadline).includes(:task)
+    @outstanding_actions = WorkflowAction.includes(workflow: [:template]).all_user_actions(current_user).where.not(completed: true).where.not(deadline: nil).where(company: @company).order(:deadline).includes(:task)
 
     @reminder_count = current_user.reminders.count
 


### PR DESCRIPTION
# Description

1. **Show outstanding workflow in Symphony Dashboard only from the current user's company**

Trello link: https://trello.com/c/FziDc9yF

## Remarks

nil

# Testing
- Checked manually from the admin backend whether the workflow is from current user's company

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
