### PR TITLE
Clear xero session when user switch company

### DIFF
--- a/app/controllers/symphony/users_controller.rb
+++ b/app/controllers/symphony/users_controller.rb
@@ -46,9 +46,9 @@ class Symphony::UsersController < ApplicationController
 
   def change_company
     if @user.update(user_params)
-      redirect_to symphony_root_path, notice: "Company changed to #{Company.find(user_params[:company_id]).name}."
       #clear xero session after switching company successfully
       session[:xero_auth].clear
+      redirect_to symphony_root_path, notice: "Company changed to #{Company.find(user_params[:company_id]).name}."
     else
       redirect_to symphony_root_path, error: 'Unable to switch companies.'
     end


### PR DESCRIPTION
# Description

Automatically clear xero session[:auth] when user switches company. User will then have to authenticate everytime xero API is called after switching company.

Trello link: https://trello.com/c/bqDxvWv3

## Remarks
Only tested on invoice task.

# Testing
- Generate 2 workflows from 2 different companies that requires invoice task (because this is where xero api is called), create invoice in one of the workflow and connect to a xero account. Afterwards, switch to the other company and create invoice in the other company's workflow. Xero will ask for authentication to connect again. 

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
