### PR TITLE
Add safe operator so that workflow can be archived without client

### DIFF
--- a/app/controllers/symphony/workflows_controller.rb
+++ b/app/controllers/symphony/workflows_controller.rb
@@ -115,7 +115,7 @@ class Symphony::WorkflowsController < WorkflowsController
     if generate_archive.success?
       redirect_to symphony_archive_path(@template.slug, @workflow.identifier), notice: 'Workflow was successfully archived.'
     else
-      redirect_to symphony_workflow_path(@template.slug, @workflow.identifier), alert: 'There was an error archiving this workflow. Please contact your admin with details of this error.'
+      redirect_to symphony_workflow_path(@template.slug, @workflow.identifier), alert: "There was an error archiving this workflow. Please contact your admin with details of this error: #{generate_archive.message}."
     end
   end
 

--- a/app/services/generate_archive.rb
+++ b/app/services/generate_archive.rb
@@ -21,7 +21,7 @@ class GenerateArchive
   private
 
   def generate_archive
-    { workflow: { user: @workflow.user.full_name, remarks: @workflow.remarks, deadline: @workflow.deadline, company: @workflow.company.name, activity_log: activity_log.to_a, archived_at: Time.current, data: @workflow.data, client_type: @workflow.workflowable_type, client_name: @workflow.workflowable.name, client_identifier: @workflow.workflowable.identifier, client_company: @workflow.workflowable.company.name, template: generate_archive_template } }
+    { workflow: { user: @workflow.user.full_name, remarks: @workflow.remarks, deadline: @workflow.deadline, company: @workflow.company.name, activity_log: activity_log.to_a, archived_at: Time.current, data: @workflow.data, client_type: @workflow.workflowable_type, client_name: @workflow.workflowable&.name, client_identifier: @workflow.workflowable&.identifier, client_company: @workflow.workflowable&.company&.name, template: generate_archive_template } }
   end
 
   def generate_archive_template
@@ -42,7 +42,7 @@ class GenerateArchive
     archive_tasks = []
     workflow_actions = WorkflowAction.where(workflow: @workflow).joins(:task).where(tasks: { section_id: section.id })
     workflow_actions.each do |action|
-      archive_task = { instructions: action.task.instructions, position: action.task.position, image_url: action.task.image_url, link_url: action.task.link_url, role_name: action.task.role&.display_name, task_type: action.task.task_type, workflow_actions: { completed: action.completed, deadline: action.deadline, company: action.company.name, assigned_user: action.assigned_user&.full_name, completed_user: action.completed_user&.full_name, remarks: action.remarks } }
+      archive_task = { instructions: action.task.instructions, position: action.task.position, image_url: action.task.image_url, link_url: action.task.link_url, role_name: action.task.role&.display_name, task_type: action.task.task_type, workflow_actions: { completed: action.completed, deadline: action.deadline, company: action.company&.name, assigned_user: action.assigned_user&.full_name, completed_user: action.completed_user&.full_name, remarks: action.remarks } }
       archive_tasks << archive_task
     end
     archive_tasks


### PR DESCRIPTION
# Description
- Workflow gives back an error while archiving. Reason is because now workflow doesn't require client field, which results in generating archive error due to no name found. Solution is to add safe operator to the workflowable.
- Show error message in the alert notice when generating archive fails.

Trello link: https://trello.com/c/452IDrV3

## Remarks
- nil

# Testing
- Test workflow to be archived successfully.

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
