### PR TITLE
Add conditional to fix error where session xero_auth is nil

### DIFF
--- a/app/controllers/symphony/users_controller.rb
+++ b/app/controllers/symphony/users_controller.rb
@@ -46,8 +46,8 @@ class Symphony::UsersController < ApplicationController
 
   def change_company
     if @user.update(user_params)
-      #clear xero session after switching company successfully
-      session[:xero_auth].clear if session[:xero_auth].exists?
+      #clear xero session after switching company successfully and check that session is present
+      session[:xero_auth].clear if session[:xero_auth].present?
       redirect_to symphony_root_path, notice: "Company changed to #{Company.find(user_params[:company_id]).name}."
     else
       redirect_to symphony_root_path, error: 'Unable to switch companies.'


### PR DESCRIPTION
# Description

Fix error: NoMethodError: undefined method `clear' for nil:NilClass
Error may be due to session[:xero_auth] being nil, and hence cant find method 'clear'.
Added conditional to clear session only when session exists

Trello link: https://trello.com/c/{card-id}

## Remarks

-

# Testing
- Logout, login again and try to switch company. Error occurs. After adding the conditional statement, i can login and switch company with no errors

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [x] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
