### PR TITLE
Update excide favicon

### DIFF
--- a/app/views/layouts/admin/application.html.slim
+++ b/app/views/layouts/admin/application.html.slim
@@ -1,0 +1,21 @@
+doctype html
+html
+  head
+    meta charset="utf-8"
+    meta content="NOODP" name="ROBOTS"
+    meta content="initial-scale=1" name="viewport"
+    title
+      = content_for(:title)
+      | - #{Rails.application.class.parent_name.titlecase}
+
+    = render "application/favicon"
+    = render "stylesheet"
+    = csrf_meta_tags
+  body
+    = render "icons"
+    .app-container
+      = render "navigation"
+      main.main-content role="main"
+        = render "flashes"
+        = yield
+    = render "javascript"


### PR DESCRIPTION
# Description

- Excide favicon is ready, only `/admin` page is not ready. so in this PR i add favicon on admin page `/admin`

Trello link: https://trello.com/c/HA6V3HTt

## Remarks

- No remarks

# Testing

- excide logo in tab on the top browser

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [x] I have added instructions and data required to test the code
- [x] I have tested the changes on the front-end on Chrome, Firefox and IE
