### PR TITLE
Save the invoice after sending invoice to xero to save changes

### DIFF
--- a/app/controllers/symphony/workflows_controller.rb
+++ b/app/controllers/symphony/workflows_controller.rb
@@ -158,6 +158,7 @@ class Symphony::WorkflowsController < WorkflowsController
       @workflow.documents.each do |document|
         xero_invoice.attach_data(document.filename, open(URI('http:' + document.file_url)).read, MiniMime.lookup_by_filename(document.file_url).content_type)
       end
+      @workflow.invoice.save
       @invoice_payable = @xero.get_invoice(@workflow.invoice.xero_invoice_id)
       #this is to send invoice to xero 'awaiting approval'
       if params[:approved].present?


### PR DESCRIPTION
# Description
- Problem: User can still see the buttons 'send to awaiting approval' and 'send to awaiting payment' even after sending to xero
- Now user cannot send invoice to xero twice. Rather, the button 'view invoice' is display instead

Trello link: https://trello.com/c/{card-id}

## Remarks
- Nil

# Testing
- Tested by sending the invoice to xero

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
