### PR TITLE
Fix js dropzone upload files for each task in workflow

### DIFF
--- a/app/assets/javascripts/components/multiple_uploads.js
+++ b/app/assets/javascripts/components/multiple_uploads.js
@@ -8,6 +8,42 @@ $(document).ready(function () {
     }
   })
 
+  //upload documents on workflows page
+  $( ".action_id" ).each(function( index ) {
+    var action_id = $(this).attr('id')
+    var workflow_action_id = $('#'+action_id).val();
+
+    if($(".uploadToXero"+workflow_action_id).length){
+      var cleanFilename = function (name) {
+        fileName = name.split('.').slice(0, -1).join('.')
+        get_extension = name.substring(name.lastIndexOf(".") + 1)
+        // Filter out special characters and spaces in filename (same as parametrize function in rails)
+        filter_filename = fileName.toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/(^-|-$)/g,'');
+        return filter_filename + '.' + get_extension;
+      };
+      var documentUploadToXero = new Dropzone(".uploadToXero"+workflow_action_id,{
+        timeout: 0,
+        renameFilename: cleanFilename,
+      })
+      documentUploadToXero.on("success", function(file, request){
+        var resp = $.parseXML(request);
+        var filePath = $(resp).find("Key").text();
+        var location = new URL($(resp).find("Location").text());
+        if($("#uploadToXero"+workflow_action_id).length){
+          //check this part of drag and drop
+          $.post('/symphony/documents', {
+            authenticity_token: $.rails.csrfToken(),
+            workflow: $('#workflow_identifier').val(),
+            document: {
+              filename: file.upload.filename,
+              file_url: '//' + location['host'] + '/' + filePath
+            }
+          });
+        }
+      })
+    }
+  });
+
   if($(".uploadToXero").length){
     var cleanFilename = function (name) {
       fileName = name.split('.').slice(0, -1).join('.')

--- a/app/views/symphony/workflows/tasks/_upload_multiple_files.html.slim
+++ b/app/views/symphony/workflows/tasks/_upload_multiple_files.html.slim
@@ -17,13 +17,14 @@ tr
         i.fa aria-hidden="true"
 tr
   td.p-0.border-top-0 colspan="6"
-    div id="task_#{task.id}" class="#{task == @workflow.current_task or @workflow.template.unordered? ? 'collapse show' : 'collapse'}" 
+    div id="task_#{task.id}" class="#{task == @workflow.current_task or @workflow.template.unordered? ? 'collapse show' : 'collapse'}"
       .m-3
         h6 Actions:
         .form-group
         	= label_tag "Drag and Drop"
         = hidden_field_tag 'workflow', @workflow.identifier, id: 'workflow_identifier'
-        = form_tag @s3_direct_post.url, class: 'dropzone uploadToXero', id: 'uploadToXero'
+        = hidden_field_tag 'action_id', action.id, id: "action_id_#{action.id}", class: "action_id"
+        = form_tag @s3_direct_post.url, class: "dropzone uploadToXero#{action.id}", id: "uploadToXero#{action.id}"
         	- @s3_direct_post.fields.each do |key, value|
         		= hidden_field_tag key, value
         br


### PR DESCRIPTION
# Description

Allow multiple tasks with dropzones in workflows page. 
For this case, we need to loop the dropzone class, because if we don't loop the class dropzone will appear only one.

Trello link: https://trello.com/c/pynp5CSo

## Remarks

- No remarks

# Testing

- New workflow with task upload multiple file 

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [x] I have added instructions and data required to test the code
- [x] I have tested the changes on the front-end on Chrome, Firefox and IE
