### PR TITLE
Undo taking out workflow identifier

### DIFF
--- a/app/assets/javascripts/components/multiple_uploads.js
+++ b/app/assets/javascripts/components/multiple_uploads.js
@@ -31,7 +31,6 @@ $(document).ready(function () {
           workflow: $('#workflow_identifier').val(),
           document: {
             filename: file.upload.filename,
-            identifier: (new Date()).toISOString().replace(/[^\w\s]/gi, '') + '-' + file.upload.filename,
             file_url: '//' + location['host'] + '/' + filePath
           }
         });
@@ -73,9 +72,9 @@ $(document).ready(function () {
           authenticity_token: $.rails.csrfToken(),
           document_type: 'batch-uploads',
           count: this.files.length,
+          workflow_identifier: (new Date()).toISOString().replace(/[^\w\s]/gi, '') + '-' + file.upload.filename,
           document: {
             filename: file.upload.filename,
-            identifier: (new Date()).toISOString().replace(/[^\w\s]/gi, '') + '-' + file.upload.filename,
             file_url: '//' + location['host'] + '/' + filePath,
             template_id: $('#template_id').val(),
           }


### PR DESCRIPTION
# Description
Error: undefined method `parameterize' for nil:NilClass in staging

Batch uploading error occurs as cannot find params[:workflow_identifier]. Changed the javascript files accidentally and remove params[:workflow_identifier]. Did the necessary amendment by adding in params[:workflow_identifier] and remove document's identifier in the js file.

Trello link: https://trello.com/c/{card-id}

## Remarks
- Test with staging

# Testing
- Tested by batch uploading on local

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
