### PR TITLE
Change field type of document id in admin

### DIFF
--- a/app/dashboards/document_dashboard.rb
+++ b/app/dashboards/document_dashboard.rb
@@ -9,7 +9,7 @@ class DocumentDashboard < Administrate::BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     company: Field::BelongsTo,
-    id: Field::Number,
+    id: Field::String,
     filename: Field::String,
     remarks: Field::Text,
     date_signed: Field::DateTime,


### PR DESCRIPTION
# Description

- Change field type of document id in admin

Trello link: https://trello.com/c/2eDSLY2M

## Remarks

- none

# Testing

-  no error field type of id on document page in admin

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [x] I have tested the changes on the front-end on Chrome, Firefox and IE
