### PR TITLE
Add validation to batch uploading.

### DIFF
--- a/app/assets/javascripts/components/multiple_uploads.js
+++ b/app/assets/javascripts/components/multiple_uploads.js
@@ -17,7 +17,7 @@ $(document).ready(function () {
       return filter_filename + '.' + get_extension;
     };
     var documentUploadToXero = new Dropzone(".uploadToXero",{
-      timeout: 0, 
+      timeout: 0,
       renameFilename: cleanFilename,
     })
     documentUploadToXero.on("success", function(file, request){
@@ -48,11 +48,14 @@ $(document).ready(function () {
       return filter_filename + '.' + get_extension;
     };
     var documentUpload = new Dropzone(".multiple_uploads", {
-      timeout: 0, 
+      timeout: 0,
       renameFilename: cleanFilename,
       autoProcessQueue: false,
       parallelUploads: 100,
       uploadMultiple: false,
+    });
+    documentUpload.on("addedfile", function () {
+      $('#drag-and-drop-submit').removeAttr('disabled');
     });
     $("#drag-and-drop-submit").click(function(){
       documentUpload.processQueue();
@@ -62,7 +65,7 @@ $(document).ready(function () {
           template_id: $('#template_id').val(),
         }
       });
-    })
+    });
     documentUpload.on("success", function (file, request) {
       var resp = $.parseXML(request);
       var filePath = $(resp).find("Key").text();

--- a/app/views/symphony/batches/new.html.slim
+++ b/app/views/symphony/batches/new.html.slim
@@ -13,4 +13,4 @@
       - @s3_direct_post.fields.each do |key, value|
         = hidden_field_tag key, value
     = hidden_field_tag 'template_id', @template.slug
-    = submit_tag 'Submit', class: 'btn btn-primary mt-2', id: 'drag-and-drop-submit'
+    = submit_tag 'Submit', disabled: true, class: 'btn btn-primary mt-2', id: 'drag-and-drop-submit'


### PR DESCRIPTION
Previously, a batch with no files can be uploaded.

# Description

Added a disabled attribute to the button on the new batch page. 
Upon additional of file into the dropzone, the attribute is removed and button is enabled.

Trello link: https://trello.com/c/cZ4Us1Fn

## Remarks

[Are there any issues to take note of? For example, anything that might cause problems or any code that can be refactored in the future.]

# Testing

Made a new batch and checked both methods of dropping and adding the file.

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
