### PR TITLE
Fix table width on document search index page

### DIFF
--- a/app/views/symphony/documents/index.html.slim
+++ b/app/views/symphony/documents/index.html.slim
@@ -41,18 +41,18 @@ javascript:
 
   loadExtJS('//cdn.jsdelivr.net/instantsearch.js/1/instantsearch.min.js', function(){
     var hitTemplate = '<table class="table table-striped">' +
-        '<thead><tr><th>Filename</th>' +
-        '<th>Document Template</th>' +
-        '<th>Workflow</th>' +
-        '<th>Uploaded At</th>' +
-        '<th>Actions</th>' +
+        '<thead><tr><th width="20%">Filename</th>' +
+        '<th width="20%">Document Template</th>' +
+        '<th width="20%">Workflow</th>' +
+        '<th width="20%">Uploaded At</th>' +
+        '<th width="20%">Actions</th>' +
         '</tr></thead>' +
         '<tbody>{{#hits}}' +
         '<tr><td>{{{_highlightResult.filename.value}}}</td>' +
         '<td>{{{_highlightResult.document_template.title.value}}}</td>' +
         '<td><a href="/symphony/{{workflow.template_slug}}/{{workflow.id}}">{{{_highlightResult.workflow.template_title.value}}}</td>' +
         '<td>{{created_at}}</td>' +
-        '<td><a href="/symphony/documents/{{objectID}}" class="btn btn-primary btn-sm mr-1">View</a> <a href="{{file_url}}" class="btn btn-warning btn-sm mr-1">Download</a> </td>' +
+        '<td><a href="/symphony/documents/{{objectID}}" class="btn btn-primary btn-sm mr-1">View</a> <a href="{{file_url}}" class="btn btn-warning btn-sm mr-1 mt-1">Download</a> </td>' +
         '{{/hits}}</tbody>'
       '</div>';
       var search = instantsearch({


### PR DESCRIPTION
# Description

- Set default table size on document search index page

Trello link: https://trello.com/c/{card-id}

## Remarks

- No remarks

# Testing

- Testing on documents index page

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [x] I have added instructions and data required to test the code
- [x] I have tested the changes on the front-end on Chrome, Firefox and IE
