### PR TITLE
Create company templates from general templates

### DIFF
--- a/app/controllers/symphony/templates_controller.rb
+++ b/app/controllers/symphony/templates_controller.rb
@@ -12,10 +12,6 @@ class Symphony::TemplatesController < ApplicationController
 
   def new
     @template = Template.new
-  end
-
-  def clone
-    @template = Template.new
     @general_templates = Template.where(company: nil)
   end
 

--- a/app/views/symphony/templates/clone.html.slim
+++ b/app/views/symphony/templates/clone.html.slim
@@ -1,1 +1,0 @@
-= render partial: 'symphony/templates/create_template', locals: { title: "Clone Template", submit_text: "Clone Template" }

--- a/app/views/symphony/templates/index.html.slim
+++ b/app/views/symphony/templates/index.html.slim
@@ -7,7 +7,6 @@
     h1
       | All Templates
       .btn-toolbar.float-right
-        = link_to 'Clone Template', clone_symphony_templates_path, role: 'button', class: 'btn btn-warning mr-1' if current_user.has_role? :admin, :any
         = link_to 'Create Template', new_symphony_template_path, role: 'button', class: 'btn btn-primary'
 .row
   .col-sm-12

--- a/app/views/symphony/templates/new.html.slim
+++ b/app/views/symphony/templates/new.html.slim
@@ -1,1 +1,40 @@
-= render partial: 'create_template', locals: { title: "New Template", submit_text: "Save Template" }
+.row
+  .col-sm-12
+    ol.breadcrumb
+      li.breadcrumb-item.ml-auto
+        a href="/symphony" Symphony
+      li.breadcrumb-item Template
+.row
+  .col-md-6
+    h1 New Template
+    = form_for(@template, url: symphony_templates_path(@template) ) do |f|
+      .row
+        .col-sm-10
+          .card.mb-3
+            h5.card-header Template Details:
+            .col-sm-12.mt-3
+              .form-group
+                = f.label :title, "Title:"
+                = f.text_field :title, class: "form-control"
+              .form-group
+                = f.label :workflow_type, "Workflow Type:"
+                = f.select :workflow_type, ::Template.workflow_types.map{|k, v| [k.humanize, k]}, {}, {class: "dropdown-overlay task-items-dropdown-width"}
+      = f.submit "Save Template", class: 'btn btn-primary pull-left'
+  .col-md-6
+    h1 Clone Template
+    = form_for(@template, url: symphony_templates_path(@template) ) do |f|
+      .row
+        .col-md-10
+          .card.mb-3
+            h5.card-header Template Details:
+            .col-sm-12.mt-3
+              .form-group
+                = f.label :title, "Title:"
+                = f.text_field :title, class: "form-control"
+              .form-group
+                = label_tag :clone, "Template:"
+                = select_tag "template[clone]", options_from_collection_for_select(@general_templates, "id", "title"), class: "selectize"
+              .form-group
+                = f.label :workflow_type, "Workflow Type:"
+                = f.select :workflow_type, ::Template.workflow_types.map{|k, v| [k.humanize, k]}, {}, {class: "dropdown-overlay task-items-dropdown-width"}
+      = f.submit "Clone Template", class: 'btn btn-primary pull-left'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,11 +34,7 @@ Rails.application.routes.draw do
     get '/search', to: 'home#search'
     post '/workflow/task/toggle-all', to: 'workflows#toggle_all', as: :task_toggle_all
 
-    resources :templates, param: :template_slug, except: [:destroy] do
-      collection do
-        get '/clone', to: 'templates#clone', as: :clone
-      end
-    end
+    resources :templates, param: :template_slug, except: [:destroy]
     post '/templates/:template_slug/create_section', to: 'templates#create_section', as: :create_section
     delete '/templates/:template_slug/destroy_section', to: 'templates#destroy_section', as: :destroy_section
 


### PR DESCRIPTION
# Description

- Allow creation template from general templates (clone template), an admin can clone template from general templates.

Trello link: https://trello.com/c/bfowjKop

## Remarks

- none

# Testing

- On manage templates page, click "clone templates" button
- Clone a template depend by template field
- After clone template, it should redirect to edit template

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [x] I have tested the changes on the front-end on Chrome, Firefox and IE
