### PR TITLE
Fix route parameter and class name from workflow identifier to workflow id

### DIFF
--- a/app/views/notification_mailer/task_notification.html.inky-slim
+++ b/app/views/notification_mailer/task_notification.html.inky-slim
@@ -1,17 +1,17 @@
 container
   row.collapse
-    columns small="6" valign="middle" 
+    columns small="6" valign="middle"
       = image_tag("excide-logo.png", style: "width: 50%; height: 50%")
-  spacer size="16" 
+  spacer size="16"
   row
     columns
       p Hi #{@user.first_name},
       p
-        | You have a new task that you are required to complete         
-        - if @action.deadline.present?  
-          |  by #{@action.deadline.strftime("%d/%m/%Y")} 
-        |. 
+        | You have a new task that you are required to complete
+        - if @action.deadline.present?
+          |  by #{@action.deadline.strftime("%d/%m/%Y")}
+        |.
       p
         ' The instructions for the task are as follows: "#{@task.instructions}". You can access the task from this link:
-        a href="#{symphony_workflow_url(@task.section.template.slug, @action.workflow.identifier)}" #{@task.section.template.title} - #{@action.workflow.identifier}
+        a href="#{symphony_workflow_url(@task.section.template.slug, @action.workflow.id)}" #{@task.section.template.title} - #{@action.workflow.id}
       p If you have any queries regarding your task, please contact the workflow creator: #{@action.workflow.user.first_name}.

--- a/app/views/symphony/batches/tasks/_send_xero_email.html.slim
+++ b/app/views/symphony/batches/tasks/_send_xero_email.html.slim
@@ -1,3 +1,3 @@
 = render "symphony/batches/tasks/workflow_type_conditions", action: action, task: action.task, workflow: workflow
 br
-= link_to "Send Email", send_email_to_xero_symphony_workflow_path(workflow_name: workflow.template.slug, workflow_identifier: workflow.identifier), class: 'btn btn-primary btn-sm'
+= link_to "Send Email", send_email_to_xero_symphony_workflow_path(workflow_name: workflow.template.slug, workflow_id: workflow.id), class: 'btn btn-primary btn-sm'

--- a/app/views/symphony/batches/tasks/_upload_file.html.slim
+++ b/app/views/symphony/batches/tasks/_upload_file.html.slim
@@ -1,3 +1,3 @@
 = render "symphony/batches/tasks/workflow_type_conditions", action: action, task: action.task, workflow: workflow
 br
-= link_to 'Upload File', new_symphony_document_path(workflow: workflow.identifier), role: 'button', target: "_blank", class: 'btn btn-primary btn-sm'
+= link_to 'Upload File', new_symphony_document_path(workflow: workflow.id), role: 'button', target: "_blank", class: 'btn btn-primary btn-sm'

--- a/app/views/symphony/batches/tasks/_upload_multiple_files.html.slim
+++ b/app/views/symphony/batches/tasks/_upload_multiple_files.html.slim
@@ -1,6 +1,6 @@
 = render "symphony/batches/tasks/workflow_type_conditions", action: action, task: action.task, workflow: workflow
 br
-= hidden_field_tag 'workflow', workflow.identifier, id: "workflow_id_#{action.id}"
+= hidden_field_tag 'workflow', workflow.id, id: "workflow_id_#{action.id}"
 = hidden_field_tag 'action_id', action.id, id: "action_id_#{action.id}", class: "action_id"
 = form_tag @s3_direct_post.url, class: "dropzone uploadToXero#{action.id}", id: "uploadToXero#{action.id}"
   - @s3_direct_post.fields.each do |key, value|

--- a/app/views/symphony/batches/tasks/_upload_photo.html.slim
+++ b/app/views/symphony/batches/tasks/_upload_photo.html.slim
@@ -1,3 +1,3 @@
 = render "symphony/batches/tasks/workflow_type_conditions", action: action, task: action.task, workflow: workflow
 br
-= link_to "Take Photo", new_symphony_document_path(workflow: workflow.identifier, params: {camera: true}), role: 'button', class: 'btn btn-primary btn-sm'
+= link_to "Take Photo", new_symphony_document_path(workflow: workflow.id, params: {camera: true}), role: 'button', class: 'btn btn-primary btn-sm'

--- a/app/views/symphony/workflows/_history.html.slim
+++ b/app/views/symphony/workflows/_history.html.slim
@@ -13,4 +13,4 @@
           tr = render_activity activity
   - if (@activities.count > 10) and @workflow.archive.blank?
     .card-footer
-      = link_to "View more...", activities_symphony_workflow_path(workflow_identifier: @workflow.identifier), class: 'btn btn-sm btn-outline-secondary float-right'
+      = link_to "View more...", activities_symphony_workflow_path(workflow_id: @workflow.id), class: 'btn btn-sm btn-outline-secondary float-right'

--- a/app/views/symphony/workflows/_invoice.html.slim
+++ b/app/views/symphony/workflows/_invoice.html.slim
@@ -7,7 +7,7 @@
       li.list-group-item
         .media
           .align-self-center
-            = link_to symphony_invoice_path(workflow_name: @workflow.template.slug, workflow_identifier: @workflow.identifier, id: @invoice.id)
+            = link_to symphony_invoice_path(workflow_name: @workflow.template.slug, workflow_id: @workflow.id, id: @invoice.id)
               i.ti-receipt.icon.mr-3 style="font-size: 50px"
           .media-body
             h5.card-title = @invoice.id

--- a/app/views/symphony/workflows/tasks/_upload_multiple_files.html.slim
+++ b/app/views/symphony/workflows/tasks/_upload_multiple_files.html.slim
@@ -22,7 +22,7 @@ tr
         h6 Actions:
         .form-group
         	= label_tag "Drag and Drop"
-        = hidden_field_tag 'workflow', @workflow.id, id: "workflow_identifier_#{action.id}"
+        = hidden_field_tag 'workflow', @workflow.id, id: "workflow_id_#{action.id}"
         = hidden_field_tag 'action_id', action.id, id: "action_id_#{action.id}", class: "action_id"
         = form_tag @s3_direct_post.url, class: "dropzone uploadToXero#{action.id}", id: "uploadToXero#{action.id}"
         	- @s3_direct_post.fields.each do |key, value|


### PR DESCRIPTION
# Description

Currently workflow identifier is not use and change to workflow id, so need fix some routes and class name still using workflow identifier change to workflow id. and this is fix issue on rollbar [https://rollbar.com/excide/excide/items/231/?item_page=0&#traceback](url)

Trello link: -

## Remarks

- No remarks

# Testing

- Testing on notification task mailer

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code thoroughly
- [ ] The code does not break existing functionality
- [x] I have added instructions and data required to test the code
- [x] I have tested the changes on the front-end on Chrome, Firefox and IE
