### PR TITLE
Refactor/update archive sections in database to section name

### DIFF
--- a/app/controllers/symphony/archives_controller.rb
+++ b/app/controllers/symphony/archives_controller.rb
@@ -30,7 +30,6 @@ class Symphony::ArchivesController < ApplicationController
     select_section = params[:section] ? @sections.find{|section| section['position'] == params[:section].to_i} : @sections.last
     @section = OpenStruct.new(select_section)
     @tasks = select_section['tasks'].sort_by{|task| task['position']}
-    @section_index = @sections.index(select_section)
     @activities = @workflow.activities
     @documents = @company.documents.where(workflow_id: @workflow.id).order(created_at: :desc)
     @document_templates = DocumentTemplate.where(template: @get_workflow.template)

--- a/app/views/symphony/workflows/_tasks.html.slim
+++ b/app/views/symphony/workflows/_tasks.html.slim
@@ -48,11 +48,11 @@
           i.fa.fa-chevron-right
     - else
       - unless @sections.first['section_name'] == @section['section_name']
-        = link_to "?section=#{@sections[@section_index - 1]['position']}", class: 'btn btn-sm btn-outline-secondary float-left'
+        = link_to "?section=#{@section['position'] - 1}", class: 'btn btn-sm btn-outline-secondary float-left'
           i.fa.fa-chevron-left
           |  Previous Section
       - unless @sections.last['section_name'] == @section['section_name']
-        = link_to "?section=#{@sections[@section_index + 1]['position']}", class: 'btn btn-sm btn-outline-secondary float-right'
+        = link_to "?section=#{@section['position'] + 1}", class: 'btn btn-sm btn-outline-secondary float-right'
           ' Next Section
           i.fa.fa-chevron-right
     .clearfix


### PR DESCRIPTION
# Description

- Update archive in database, remove attribute display_name and unique_name and use section_name instead. Use position of section for next and previous section.

Trello link: https://trello.com/c/UakOOwib

## Remarks

- For staging i will update the archive in database, but the archive show page still show the error. The error will not show if this PR merge with master and push to staging.

# Testing

- Update the archive in database, use `rails console`, and run this commands : 
```
workflows = Workflow.select{|w| w.archive.present?}

workflows.each do |w|
 w.archive[“workflow”][“template”][“sections”].each do |s|
   s[“section_name”] = s[“unique_name”]
   s.delete(“display_name”)
   s.delete(“unique_name”)
 end
 w.save
end
```

- To check the attribute of archive is changed (get all section_name) :
```
workflows.map{ |w| w.archive["workflow"]["template"]["sections"].map{|s| s["section_name"]} }
```

- Open any archive show page, it should not show the errors


## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [ ] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [x] I have tested the changes on the front-end on Chrome, Firefox and IE
