### PR TITLE
Add safe operator to account for batches with no user

### DIFF
--- a/app/views/symphony/batches/index.html.slim
+++ b/app/views/symphony/batches/index.html.slim
@@ -26,7 +26,7 @@
               tr
                 td = link_to batch.id, symphony_batch_path(id: batch.id, batch_template_name: batch.template.slug)
                 td = batch.template.title
-                td = batch.user.full_name
+                td = batch.user&.full_name
                 td = batch.created_at.strftime('%m/%d/%Y %H:%M')
                 td
                   .progress


### PR DESCRIPTION
# Description

Batch index shows error with user.full_name.
Solution: Added safe operator. Error occurs when batch has no user

Trello link: https://trello.com/c/{card-id}

## Remarks
- nil

# Testing
- nil. Cant produce that error on local

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
