### PR TITLE
Fix error: Unable to save client details in EDIT page

### DIFF
--- a/app/controllers/symphony/workflows_controller.rb
+++ b/app/controllers/symphony/workflows_controller.rb
@@ -73,7 +73,7 @@ class Symphony::WorkflowsController < WorkflowsController
   def update
     if @workflow.update(workflow_params)
       #if workflow.workflowable is present, don't need to create client. If no workflowable params is posted(such as in the case of data-entry), no client is created too.
-      @workflow.workflowable = Client.create(name: params[:workflow][:client][:name], identifier: params[:workflow][:client][:identifier], company: @company, user: current_user) unless @workflow.workflowable.present? or params[:workflow][:workflowable].nil?
+      @workflow.workflowable = Client.create(name: params[:workflow][:client][:name], identifier: params[:workflow][:client][:identifier], company: @company, user: current_user) unless @workflow.workflowable.present? or params[:workflow][:workflowable].present?
       @workflow.save
       log_data_activity
       log_workflow_activity


### PR DESCRIPTION
# Description
Problem: Cannot create NEW client details on EDIT form
Solution: Conditionals mistake. The create of client did not pass through due to conditions pass (params[...][...][...].nil? returns true). Change condition from nil? to present? to fix the error. 

Trello link: https://trello.com/c/{card-id}

## Remarks
- nil

# Testing
- Tested by creating 5 workflows without client, then edit the form to add NEW clients.

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
