### PR TITLE
Modify code to prevent access to INDEX template for non-admin user

### DIFF
--- a/app/controllers/symphony/templates_controller.rb
+++ b/app/controllers/symphony/templates_controller.rb
@@ -6,10 +6,11 @@ class Symphony::TemplatesController < ApplicationController
   before_action :set_template, except: [:index, :new, :create, :clone]
   before_action :find_roles, only: [:new, :edit, :create_section]
 
-  after_action :verify_authorized, except: :index
+  after_action :verify_authorized
   after_action :verify_policy_scoped, only: :index
 
   def index
+    authorize Template
     @templates = policy_scope(Template)
   end
 

--- a/app/policies/template_policy.rb
+++ b/app/policies/template_policy.rb
@@ -29,12 +29,8 @@ class TemplatePolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      if user.has_role?(:admin, user.company)
-        # Scope templates from the user's company.
-        scope.where(company: user.company)
-      else
-        raise Pundit::NotAuthorizedError, 'not allowed to view this action'
-      end
+      # Scope templates from the user's company.
+      scope.where(company: user.company)
     end
   end
 


### PR DESCRIPTION
# Description
- Added condition in the scope to check for user's role admin

Trello link: https://trello.com/c/{card-id}

## Remarks
- nil

# Testing
- Tested to go into INDEX template using a non-admin user
- Tested admin user still can access index template page

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
