### PR TITLE
Enhance breadcrumbs on batches show page

### DIFF
--- a/app/views/symphony/batches/show.html.slim
+++ b/app/views/symphony/batches/show.html.slim
@@ -9,8 +9,9 @@
         a href="/symphony/batches" Batches
       li.breadcrumb-item
         a href="/symphony/#{@batch.template.slug}" #{@batch.template.title}
+      li.breadcrumb-item #{@batch.id}
     h1
-      | Batch ID - #{@batch.id}
+      | View Batch
 - @sections.each do |section|
   .card.scrollbar.mb-3
     h5.card-header = section.section_name + ' - ' + section.tasks.count.to_s + " tasks"


### PR DESCRIPTION
# Description

Modify breadcrumb to image below:
![Screenshot 2019-07-04 at 3 11 49 PM](https://user-images.githubusercontent.com/40416736/60646514-1fe1e580-9e6e-11e9-9648-f0f94fa3142e.png)

Trello link: https://trello.com/c/hQziSkSH

## Remarks
- nil

# Testing
- Tested by viewing batch SHOW

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
