### PR TITLE
Redirect back to batch page after sending invoice

### DIFF
--- a/app/controllers/symphony/invoices_controller.rb
+++ b/app/controllers/symphony/invoices_controller.rb
@@ -38,7 +38,11 @@ class Symphony::InvoicesController < ApplicationController
     end
 
     if @invoice.save
-      redirect_to symphony_invoice_path(workflow_name: @workflow.template.slug, workflow_id: @workflow.id, id: @invoice.id), notice: "Invoice created successfully!"
+      if @workflow.batch
+        redirect_to symphony_batch_path(batch_template_name: @workflow.batch.template.slug, id: @workflow.batch.id), notice: "Invoice created successfully!"
+      else
+        redirect_to symphony_invoice_path(workflow_name: @workflow.template.slug, workflow_id: @workflow.id, id: @invoice.id), notice: "Invoice created successfully!"
+      end
     else
       render 'new'
     end


### PR DESCRIPTION
# Description

Redirect back to batch page after sending invoice, if workflow related to a batch. For workflow without batch, after sending invoice it will redirect to invoice show page. 

Trello link: https://trello.com/c/WDFgHnBC

## Remarks

- none

# Testing

- Create invoice for a batch with a task "create invoice" within
- After invoice created, it will redirect back to batch show page

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [ ] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [x] I have tested the changes on the front-end on Chrome, Firefox and IE
