### PR TITLE
change instruction form to text area

### DIFF
--- a/app/views/symphony/templates/_task_fields.html.slim
+++ b/app/views/symphony/templates/_task_fields.html.slim
@@ -4,7 +4,7 @@ tr
     = link_to 'X', '#', class: 'btn btn-sm btn-danger remove_tasks'
   td.task-fields = f.number_field :position, {step: 1, class: "form-control number-width"}
   td.task-fields = f.select :task_type, Task.task_types.map{|k, v| [k.humanize, k]}, {},  {class: "dropdown-overlay"}
-  td.task-fields = f.text_field :instructions, {class: "form-control text-field-width"}
+  td.task-fields = f.text_area :instructions, {class: "form-control text-field-width"}
   td.task-fields = f.select :role_id, options_for_select(@roles.collect{|role| [role.display_name, role.id]}, selected: f.object.role&.id), {} , {class: "dropdown-overlay task-items-dropdown-width"}
   td.task-fields = f.number_field :days_to_complete, {step: 1, class: "form-control number-width"}
   td.task-fields = f.select :document_template_id, options_for_select(DocumentTemplate.all.collect{|doc_tem| [doc_tem.title, doc_tem.id]}, selected: f.object.document_template&.id), {include_blank: true}, {class: "dropdown-overlay task-items-dropdown-width mb-2"}


### PR DESCRIPTION
# Description

The change that was made was that the text field in the instruction column was changed into a text area which means more blank space for the user to write in. This is because often times instructions aren't just a few words. Rather, they are various lines.

Trello link: https://trello.com/c/fKTwFfCA

## Remarks

The text area (box) can be dragged out to be bigger or smaller by the user. Not sure if that's exactly what you guys want. 

# Testing

I saved the changes and tested on localhost to confirm the changes made.

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
