### PR TITLE
Change section_name back to unique_name

### DIFF
--- a/db/migrate/20170302093855_create_sections.rb
+++ b/db/migrate/20170302093855_create_sections.rb
@@ -1,7 +1,7 @@
 class CreateSections < ActiveRecord::Migration
   def change
     create_table :sections do |t|
-      t.string :section_name
+      t.string :unique_name
       t.string :display_name
       t.integer :position
       t.references :template, index: true, foreign_key: true


### PR DESCRIPTION
# Description

fix previous change in migration file.
from section_name back to unique_name.

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
