### PR TITLE
limiting number fields on edit template

### DIFF
--- a/app/controllers/symphony/templates_controller.rb
+++ b/app/controllers/symphony/templates_controller.rb
@@ -45,7 +45,7 @@ class Symphony::TemplatesController < ApplicationController
     if @template.update(template_params)
       redirect_to edit_symphony_template_path(@template)
     else
-      redirect_to root_path
+      redirect_to symphony_templates_path
     end
   end
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,5 @@
 class Task < ApplicationRecord
+  validates :days_to_complete, numericality: {allow_nil: true, greater_than_or_equal_to: 1}
   after_create :add_workflow_action
 
   belongs_to :section

--- a/app/views/symphony/templates/_task_fields.html.slim
+++ b/app/views/symphony/templates/_task_fields.html.slim
@@ -2,11 +2,11 @@ tr
   td.task-fields
     = f.hidden_field :_destroy
     = link_to 'X', '#', class: 'btn btn-sm btn-danger remove_tasks'
-  td.task-fields = f.number_field :position, {step: 1, class: "form-control number-width"}
+  td.task-fields = f.number_field :position, {min: 1, step: 1, class: "form-control number-width"}
   td.task-fields = f.select :task_type, Task.task_types.map{|k, v| [k.humanize, k]}, {},  {class: "dropdown-overlay"}
   td.task-fields = f.text_area :instructions, {class: "form-control text-field-width"}
   td.task-fields = f.select :role_id, options_for_select(@roles.collect{|role| [role.display_name, role.id]}, selected: f.object.role&.id), {} , {class: "dropdown-overlay task-items-dropdown-width"}
-  td.task-fields = f.number_field :days_to_complete, {step: 1, class: "form-control number-width"}
+  td.task-fields = f.number_field :days_to_complete, {min: 1, step: 1, class: "form-control number-width"}
   td.task-fields = f.select :document_template_id, options_for_select(DocumentTemplate.all.collect{|doc_tem| [doc_tem.title, doc_tem.id]}, selected: f.object.document_template&.id), {include_blank: true}, {class: "dropdown-overlay task-items-dropdown-width mb-2"}
   td.task-fields = f.text_field :link_url, {class: "form-control text-field-width"}
   td.task-fields = f.text_field :image_url, {class: "form-control text-field-width"}


### PR DESCRIPTION
# Description

[Please include a summary of the change and which issue is fixed. Please also include relevant reasons for the chosen solution and context. List any dependencies that are required for this change.]

The change that was made was that now when you go to edit your template, neither the position number or the days to complete can be under 1. 

Trello link: https://trello.com/c/{card-id}

## Remarks

[Are there any issues to take note of? For example, anything that might cause problems or any code that can be refactored in the future.]

# Testing

[Please describe the tests that you used to verify your changes. Provide instructions so that the tests can be reproduced.]

The days to complete column is coded for the outside and the inside, but since I am led to believe the position number is connected to a gem that automatically reorders the numbers, even when they are negative (to 1), the position number is coded for the outside, meaning that it can't be less than 1 unless being "hacked".

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
