### PR TITLE
Check & Approve Button changes to Invoice Approved once it is approved

### DIFF
--- a/app/views/symphony/batches/tasks/_coding_invoice.html.slim
+++ b/app/views/symphony/batches/tasks/_coding_invoice.html.slim
@@ -1,7 +1,9 @@
 = render "symphony/batches/tasks/workflow_type_conditions", action: action, task: action.task, workflow: workflow
 br
 - if workflow.invoice.present?
-  = link_to "Check & Approve Invoice", edit_symphony_invoice_path(workflow_name: workflow.template.slug, workflow_id: workflow.id, id: workflow.invoice.id), target: "_blank", class: 'btn btn-success btn-sm mb-2'
+  = link_to "Check & Approve Invoice", edit_symphony_invoice_path(workflow_name: workflow.template.slug, workflow_id: workflow.id, id: workflow.invoice.id), target: "_blank", class: 'btn btn-success btn-sm mb-2' if !workflow.invoice.approved?
+  = link_to "Invoice Approved", edit_symphony_invoice_path(workflow_name: workflow.template.slug, workflow_id: workflow.id, id: workflow.invoice.id), target: "_blank", class: 'btn btn-success btn-sm mb-2 disabled' if workflow.invoice.approved?
+
   br
   = link_to "Delete Invoice", symphony_invoice_path(workflow_name: workflow.template.slug, workflow_id: workflow.id, id: workflow.invoice.id), method: :delete, target: "_blank", class: 'btn btn-danger btn-sm', data: { confirm: 'Are you sure you want to delete this invoice?' }
 - else

--- a/app/views/symphony/workflows/tasks/_coding_invoice.html.slim
+++ b/app/views/symphony/workflows/tasks/_coding_invoice.html.slim
@@ -23,7 +23,8 @@ tr
         .btn-toolbar role="toolbar"
           .btn-group.mr-2 role="group" aria-label="Task actions"
             - if @workflow.invoice.present?
-              = link_to "Check & Approve Invoice", edit_symphony_invoice_path(workflow_name: @workflow.template.slug, workflow_id: @workflow.id, id: @workflow.invoice.id), class: 'btn btn-success btn-sm mr-2'
+              = link_to "Invoice Approved", edit_symphony_invoice_path(workflow_name: @workflow.template.slug, workflow_id: @workflow.id, id: @workflow.invoice.id), class: 'btn btn-success btn-sm mr-2 disabled' if @workflow.invoice.approved?
+              = link_to "Check & Approve Invoice", edit_symphony_invoice_path(workflow_name: @workflow.template.slug, workflow_id: @workflow.id, id: @workflow.invoice.id), class: 'btn btn-success btn-sm mr-2' if !@workflow.invoice.approved?
               = link_to "Delete Invoice", symphony_invoice_path(workflow_id: params[:workflow_id], id: @workflow.invoice.id), method: :delete, class: 'btn btn-danger btn-sm', data: { confirm: 'Are you sure you want to delete this invoice?' }
             - else
               = link_to "No invoice found", '#', role: 'button', class: 'btn btn-success btn-sm disabled'


### PR DESCRIPTION
# Description

The change that was made is that now, once an invoice is approved in workflows and batches, the button will no longer read "Check & Approve Button", but rather read "Invoice Approved". Not only that, the button would be disabled meaning that the user won't be able to click on the button. 

Trello link: https://trello.com/c/xiPGzi9n

## Remarks

Making the button disabled wasn't exactly in the trello task but it could easily be taken out if it shouldn't be there, but in this situation it makes sense to disable it after it is approved. 

# Testing

Multiple checks on the localhost website to check the validity of the code, and to make sure it does what it's supposed to do. 

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
