### PR TITLE
disabled checkbox for unordered workflow

### DIFF
--- a/app/views/symphony/workflows/tasks/_workflow_type_conditions.html.slim
+++ b/app/views/symphony/workflows/tasks/_workflow_type_conditions.html.slim
@@ -9,3 +9,6 @@
   - if action.assigned_user == current_user or task.role_id == nil or (@roles.map(&:id).include? task.role_id) or (@user.has_role? :admin, @company)
     = check_box_tag 'completed', action.id, action.completed, data: {remote: true, url: url_for(action: :toggle, task_id: task.id), method: "POST"}, onclick: "this.checked=true;" if !action.completed?
     = check_box_tag 'completed', action.id, action.completed, disabled: true if action.completed?
+  - else
+    = check_box_tag 'completed', action.id, action.completed, disabled: true
+


### PR DESCRIPTION
# Description

There was no checkbox for tasks that do not belong to user.
Add disabled checkbox

Trello link: https://trello.com/c/W78iK02x

## Remarks

# Testing

Create ordered and unordered workflows with tasks assigned to admin, associate and shared service.

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
