### PR TITLE
Authorize workflow in send_email_to_xero method

### DIFF
--- a/app/controllers/symphony/workflows_controller.rb
+++ b/app/controllers/symphony/workflows_controller.rb
@@ -235,6 +235,7 @@ class Symphony::WorkflowsController < ApplicationController
   end
 
   def send_email_to_xero
+    authorize @workflow
     @workflow.documents.each do |workflow_docs|
         WorkflowMailer.send_invoice_email(@workflow, workflow_docs).deliver_later
     end


### PR DESCRIPTION
# Description

Error came from the after action verify_authorized but there was no authorize @workflow in send_email_to_xero method.
Add  authorize @workflow in send_email_to_xero method.

Trello link: https://trello.com/c/7GvgpF1i

## Remarks

# Testing

manage to send email to xero.

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
