### PR TITLE
gap no longer exists in archives template page

### DIFF
--- a/app/views/symphony/workflows/_tasks.html.slim
+++ b/app/views/symphony/workflows/_tasks.html.slim
@@ -57,7 +57,6 @@
                                     h5.text-truncate = d.filename
                                     h6.card-subtitle = d.user&.full_name
                                     .text-muted = d.created_at.strftime("Uploaded at %d/%m/%Y %R")
-            br
   .card-footer
     - if @workflow.archive.blank?
       - unless @section.first?


### PR DESCRIPTION
# Description

The issue that was fixed is that the gap previously on the archives template page is no longer there, and it just shows the card header then immediately to the table. 

Trello link: https://trello.com/c/k9fR2WKu

## Remarks

None

# Testing

Checked multiple times through localhost to check that the weird gap was no longer present on the archives template page after deleting the small piece of code
## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
