### PR TITLE
Fix return nil item description in get items xero

### DIFF
--- a/app/controllers/symphony/invoices_controller.rb
+++ b/app/controllers/symphony/invoices_controller.rb
@@ -137,7 +137,7 @@ class Symphony::InvoicesController < ApplicationController
     @tracking_name          = @xero.get_tracking_options
     @tracking_categories_1  = @tracking_name[0]&.options&.map{|option| option}
     @tracking_categories_2  = @tracking_name[1]&.options&.map{|option| option}
-    @items                  = @xero.get_items.map{|item| (item.code + ': ' + item.description) if item.code.present?}
+    @items                  = @xero.get_items.map{|item| (item.code + ': ' + (item.description || '-')) if item.code.present?}
   end
 
   def invoice_params


### PR DESCRIPTION
# Description

Fix return error when description of item code is nil.

Trello link: https://trello.com/c/{card-id}

## Remarks

- No remarks

# Testing

- Testing on create and edit invoice

## Checklist:

- [ ] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code thoroughly
- [ ] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
