### PR TITLE
Modify ENV for oauth callback to suit rails environment

### DIFF
--- a/app/controllers/xero_sessions_controller.rb
+++ b/app/controllers/xero_sessions_controller.rb
@@ -2,8 +2,7 @@ class XeroSessionsController < ApplicationController
 
   def self.connect_to_xero(session)
     @xero_client = Xeroizer::PartnerApplication.new(ENV["XERO_CONSUMER_KEY"], ENV["XERO_CONSUMER_SECRET"], "| echo \"#{ENV["XERO_PRIVATE_KEY"]}\" ")
-    request_token = @xero_client.request_token(oauth_callback: 'https://' + ENV['HOST_DOMAIN'] + '/xero_callback_and_update')
-    #To test on localhost, replace ENV['HOST_DOMAIN'] to localhost
+    request_token = @xero_client.request_token(oauth_callback: ENV['ASSET_HOST'] + '/xero_callback_and_update')
     session[:request_token] = request_token.token
     session[:request_secret] = request_token.secret
     request_token.authorize_url


### PR DESCRIPTION
# Description
Callback URL is different for production and development, so changed to depend on ENV['ASSET_HOST']

Trello link: https://trello.com/c/{card-id}

## Remarks
nil
# Testing

[Please describe the tests that you used to verify your changes. Provide instructions so that the tests can be reproduced.]

## Checklist:

- [ ] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code thoroughly
- [ ] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
