### PR TITLE
Change all session[:xero_auth] to depend on company

### DIFF
--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -26,7 +26,7 @@ class ClientsController < ApplicationController
     @client.user = current_user
 
     if params[:add_to_xero] == 'true'
-      @xero = Xero.new(session[:xero_auth])
+      @xero = Xero.new(@client.company)
       contact_id = @xero.create_contact(client_params)
       @client.xero_contact_id = contact_id
     end
@@ -63,7 +63,7 @@ class ClientsController < ApplicationController
   end
 
   def xero_create
-    @xero = Xero.new(session[:xero_auth])
+    @xero = Xero.new(@client.company)
     contact_id = @xero.create_contact(name: @client.name)
     @client.xero_contact_id = contact_id
 

--- a/app/controllers/conductor/clients_controller.rb
+++ b/app/controllers/conductor/clients_controller.rb
@@ -15,7 +15,7 @@ class Conductor::ClientsController < ClientsController
 
   def update
     if params[:add_to_xero] == 'true'
-      @xero = Xero.new(session[:xero_auth])
+      @xero = Xero.new(@client.company)
       contact_id = @xero.create_contact(client_params)
       @client.xero_contact_id = contact_id
     end

--- a/app/controllers/symphony/workflows_controller.rb
+++ b/app/controllers/symphony/workflows_controller.rb
@@ -40,7 +40,7 @@ class Symphony::WorkflowsController < ApplicationController
     @workflow.workflow_action_id = params[:action_id] if params[:action_id]
 
     if params[:workflow][:client][:name].present?
-      @xero = Xero.new(session[:xero_auth])
+      @xero = Xero.new(@workflow.company)
       @workflow.workflowable = Client.create(name: params[:workflow][:client][:name], identifier: params[:workflow][:client][:identifier], company: @company, user: current_user)
     end
 
@@ -232,7 +232,7 @@ class Symphony::WorkflowsController < ApplicationController
   end
 
   def xero_create_invoice_payable
-    @xero = Xero.new(session[:xero_auth])
+    @xero = Xero.new(@workflow.company)
     authorize @workflow
     if @workflow.invoice.payable?
       xero_invoice = @xero.create_invoice_payable(@workflow.invoice.xero_contact_id, @workflow.invoice.invoice_date, @workflow.invoice.due_date, @workflow.invoice.line_items, @workflow.invoice.line_amount_type, @workflow.invoice.invoice_reference, @workflow.invoice.currency)


### PR DESCRIPTION
# Description
- As we integrated to xero-partner-app, the initialize now depends on the company as the params

Trello link: https://trello.com/c/{card-id}

## Remarks
- When Xero is initialise, it checks if the token is expires by checking company.expires_at. If company is not passed in, it will return undefined method 'expires_at'

# Testing
- Tested by creating invoice and sending invoice to xero when company expires

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
