### PR TITLE
Add widget for new workflow back on dashboard page

### DIFF
--- a/app/controllers/symphony/home_controller.rb
+++ b/app/controllers/symphony/home_controller.rb
@@ -5,8 +5,10 @@ class Symphony::HomeController < ApplicationController
 
   def index
     @templates = policy_scope(Template).assigned_templates(current_user)
-    @workflows_array = policy_scope(Workflow).includes(:template, :workflowable).where(template: @templates)
-    @outstanding_actions = WorkflowAction.includes(:workflow).all_user_actions(current_user).where.not(completed: true).where.not(deadline: nil).where(company: @company).order(:deadline).includes(:task)
+    @workflow_count = policy_scope(Workflow).where(template: @templates).count
+    @outstanding_actions = WorkflowAction.includes(:workflow).all_user_actions(current_user).where.not(completed: true).where.not(deadline: nil).where(company: @company).order(:deadline).includes(:task).count
+    @batch_count = policy_scope(Batch).count
+    @reminder_count = current_user.reminders.count
     @s3_direct_post = S3_BUCKET.presigned_post(key: "uploads/#{SecureRandom.uuid}/${filename}", allow_any: ['utf8', 'authenticity_token'], success_action_status: '201', acl: 'public-read')
   end
 end

--- a/app/views/symphony/home/index.html.slim
+++ b/app/views/symphony/home/index.html.slim
@@ -1,5 +1,32 @@
 .container.mt-5
   .row
+    .col-sm-12
+      .card-deck.mb-3
+        .card.text-center.bg-light
+          .card-body
+            h5.card-title Workflows
+            h1.card-text = @workflow_count
+        .card.text-center.bg-light
+          .card-body
+            h5.card-title Tasks
+            h1.card-text = @outstanding_actions
+        .card.text-center.bg-light
+          .card-body
+            h5.card-title Batches
+            h1.card-text = @batch_count
+        .card.text-center.bg-light
+          .card-body
+           h5.card-title Reminders
+           h1.card-text = link_to @reminder_count, symphony_reminders_path, class: 'text-dark'
+  .row
+    .col-sm-6
+      .card.mb-3
+        h5.card-header New Workflow
+        .card-body
+          .form-group
+            = label_tag "template", "Select template:"
+            = select_tag "template", options_from_collection_for_select(@templates, "slug", "title"), include_blank: true, class: "selectize", onchange: "$('#new-workflow').attr('href', '/symphony/' + $(this).val() + '/new')"
+          = link_to 'New Workflow', '', class: 'btn btn-primary d-block mb-2', id: 'new-workflow'
     .col-sm-6
       .card.mb-3
         h5.card-header Batch Upload
@@ -12,13 +39,3 @@
           = form_tag @s3_direct_post.url, class: 'dropzone multiple_uploads mb-3', id: 'batch-uploader'
             - @s3_direct_post.fields.each do |key, value|
               = hidden_field_tag key, value
-    .col-sm-6
-      .card-deck.mb-3
-        .card.text-center.bg-light
-          .card-body
-            h5.card-title Workflows
-            h1.card-text = @workflows_array.count
-        .card.text-center.bg-light
-          .card-body
-            h5.card-title Tasks
-            h1.card-text = @outstanding_actions.count


### PR DESCRIPTION
# Description

Add new workflow widget was removed in a previous update but it is still a required function so it is added back in for this pull request.

Trello link: https://trello.com/c/PJDB8VIo

## Remarks

Added batch and reminder count as well to balance out the layout.

# Testing

Tested creating new workflows from the dashboard page.

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [x] I have added instructions and data required to test the code
- [x] I have tested the changes on the front-end on Chrome, Firefox and IE
