### PR TITLE
Fix show button approve delete save on invoice page when rejected

### DIFF
--- a/app/views/symphony/invoices/edit.html.slim
+++ b/app/views/symphony/invoices/edit.html.slim
@@ -79,17 +79,16 @@
                   / If xero invoice is present, only show button to view Xero invoice
                   - if @invoice.xero_invoice_id.present?
                     = link_to "View Xero invoice", "https://go.xero.com/AccountsPayable/Edit.aspx?InvoiceID=#{@invoice.xero_invoice_id}", role: 'button', target: "_blank", class: 'btn btn-warning', target: :_blank
-                  - elsif current_user.has_role? :associate, @company or current_user.has_role? :consultant, @company or current_user.has_role? :admin, @company
-                    - if @invoice.approved?
+                  - else
+                    - if @invoice.approved? and !current_user.has_role?(:shared_service, @company)
                       | Send to Xero:
                       = link_to("Awaiting Approval", xero_create_invoice_payable_symphony_workflow_path(@workflow.template.slug, @workflow.id, approved: "approved", workflow_action_id: params[:workflow_action_id]), method: 'post', role: 'button', class: 'btn btn-warning m-2')
                       = link_to("Awaiting Payment",xero_create_invoice_payable_symphony_workflow_path(@workflow.template.slug, @workflow.id, payment: "payment", workflow_action_id: params[:workflow_action_id]), method: 'post', role: 'button', class: 'btn btn-danger')
-                    - elsif @invoice.rejected?
+                    - elsif @invoice.rejected? and !current_user.has_role?(:shared_service, @company)
                       = f.submit 'Approve', class: 'btn btn-success mr-2 btn-invoice-approved'
                       = link_to "Delete", symphony_invoice_path(workflow_name: @workflow.template.slug, workflow_id: @workflow.id, id: @invoice.id), method: :delete, class: 'btn btn-danger mr-2', data: {confirm: "Are you sure you want to delete this invoice?"}
                     - else
-                      - if current_user.has_role? :shared_service, @company or current_user.has_role? :associate, @company or current_user.has_role? :consultant, @company or current_user.has_role? :admin, @company
-                        = link_to("Reject", reject_invoice_symphony_workflow_path(@workflow.template.slug, @workflow.id, id: @invoice.id, workflow_action_id: params[:workflow_action_id]), method: 'post', role: 'button', class: 'btn btn-danger mr-2')
-                        = f.submit 'Approve', class: 'btn btn-success mr-2 btn-invoice-approved' unless current_user.has_role? :shared_service, @company
+                      = link_to("Reject", reject_invoice_symphony_workflow_path(@workflow.template.slug, @workflow.id, id: @invoice.id, workflow_action_id: params[:workflow_action_id]), method: 'post', role: 'button', class: 'btn btn-danger mr-2')
+                      = f.submit 'Approve', class: 'btn btn-success mr-2 btn-invoice-approved' unless current_user.has_role? :shared_service, @company
                     = f.submit 'Save', class: 'btn btn-primary'
 


### PR DESCRIPTION
# Description

Fix show buttons (approve, delete, save) when invoice is rejected with validation role (associate, admin, superadmin, consultant)

Trello link: https://trello.com/c/hEPz3Y8W

## Remarks

- No remarks

# Testing

- Testing on edit invoice page

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [x] I have added instructions and data required to test the code
- [x] I have tested the changes on the front-end on Chrome, Firefox and IE
