### PR TITLE
Add another method to capture exception for other xero API error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,12 @@ class ApplicationController < ActionController::Base
   include PublicActivity::StoreController
 
   rescue_from Pundit::NotAuthorizedError, Pundit::AuthorizationNotPerformedError, with: :user_not_authorized
+  #TokenInvalid in case user is still using public app for xero. It will redirect them to xero authorization page
+  rescue_from Xeroizer::OAuth::TokenInvalid, with: :xero_login
+  #If record is not found on xero, it will return flash message as string
+  rescue_from Xeroizer::RecordInvalid, URI::InvalidURIError, ArgumentError, with: :xero_error
+  #Error occurs for eg, the tax rate doesn't match with account code. Xero returns an exception in XML, hence the need to parse it truncate it in the xero_error_api_exception method
+  rescue_from Xeroizer::ApiException, with: :xero_error_api_exception
 
   after_action :store_location
 
@@ -33,5 +39,26 @@ class ApplicationController < ActionController::Base
 
     flash[:alert] = t "#{policy_name}.#{exception.query}", scope: "pundit", default: :default
     redirect_to symphony_root_path
+  end
+
+  def xero_login
+    @xero_client = Xeroizer::PartnerApplication.new(ENV["XERO_CONSUMER_KEY"], ENV["XERO_CONSUMER_SECRET"], "| echo \"#{ENV["XERO_PRIVATE_KEY"]}\" ")
+    request_token = @xero_client.request_token(oauth_callback: ENV['ASSET_HOST'] + '/xero_callback_and_update')
+    session[:request_token] = request_token.token
+    session[:request_secret] = request_token.secret
+    redirect_to request_token.authorize_url
+  end
+
+  def xero_error(e)
+    message = 'Xero returned an error: ' + e.message + '. Please ensure you have filled in all the required data in the right format.'
+    Rails.logger.error("Xero Error: #{message}")
+    redirect_to session[:previous_url], alert: message
+  end
+
+  #prevent overflow cookie errors by parsing and truncating the XML exception xero returns
+  def xero_error_api_exception(e)
+    message = 'Xero returned an error: ' + e.parsed_xml.text.to_s.truncate(200) + '. Please ensure you have filled in all the required data in the right format.'
+    Rails.logger.error("Xero Error: #{message}")
+    redirect_to session[:previous_url], alert: message
   end
 end

--- a/app/controllers/symphony/workflows_controller.rb
+++ b/app/controllers/symphony/workflows_controller.rb
@@ -9,10 +9,6 @@ class Symphony::WorkflowsController < ApplicationController
   before_action :set_workflow, only: [:show, :edit, :update, :destroy, :assign, :archive, :reset, :data_entry, :xero_create_invoice_payable, :send_email_to_xero, :activities]
   before_action :set_attributes_metadata, only: [:create, :update]
 
-  rescue_from Xeroizer::OAuth::TokenInvalid, with: :xero_login
-  rescue_from Xeroizer::RecordInvalid, URI::InvalidURIError, ArgumentError, with: :xero_error
-  rescue_from Xeroizer::ApiException, with: :xero_error_api_exception
-
   after_action :verify_authorized, except: [:index, :send_reminder, :stop_reminder]
   after_action :verify_policy_scoped, only: :index
 
@@ -400,22 +396,5 @@ class Symphony::WorkflowsController < ApplicationController
       elsif params[:sort] == "identifier" then item.identifier ? item.identifier.upcase : ""
       end
     }
-  end
-
-  def xero_login
-    redirect_to user_xero_omniauth_authorize_path
-  end
-
-  def xero_error(e)
-    message = 'Xero returned an error: ' + e.message + '. Please ensure you have filled in all the required data in the right format.'
-    Rails.logger.error("Xero Error: #{message}")
-    redirect_to session[:previous_url], alert: message
-  end
-
-  #prevent overflow cookie errors by parsing and truncating the XML exception xero returns
-  def xero_error_api_exception(e)
-    message = 'Xero returned an error: ' + e.parsed_xml.text.to_s.truncate(200) + '. Please ensure you have filled in all the required data in the right format.'
-    Rails.logger.error("Xero Error: #{message}")
-    redirect_to session[:previous_url], alert: message
   end
 end


### PR DESCRIPTION
# Description
- Error was because some xero error returns back string error messages instead of XML error messages. Hence, the parsed_xml method will give back an error if its a string.
- Solution is to create another method, plainly for Xero API Validation Error as that is the only error returning XML format text

Trello link: https://trello.com/c/{card-id}

## Remarks
- nil

# Testing
- Test that Xero API validation error message still return as expected

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
