### PR TITLE
Fix argument error when updating invoice to xero

### DIFF
--- a/app/controllers/symphony/invoices_controller.rb
+++ b/app/controllers/symphony/invoices_controller.rb
@@ -74,8 +74,8 @@ class Symphony::InvoicesController < ApplicationController
       #when invoice updates with the rounding line item, update the invoice in Xero as well
       if @invoice.xero_total_mismatch?
         #In batch, check whether there is a next workflow
-        next_wf = @workflow.batch.next_workflow(@workflow)
         workflow_action = @workflow.workflow_actions.find(params[:workflow_action_id])
+        next_wf = @workflow.batch.next_workflow(@workflow, workflow_action)
 
         @xero_invoice = @xero.get_invoice(@invoice.xero_invoice_id)
         @update_xero_invoice = @xero.updating_invoice_payable(@xero_invoice, @invoice.line_items)


### PR DESCRIPTION
# Description
- Wrong argument input for the method next_workflow. Not a xero error, but all ArgumentError is captured by xero_error message.

Trello link: https://trello.com/c/{card-id}

## Remarks

[Are there any issues to take note of? For example, anything that might cause problems or any code that can be refactored in the future.]

# Testing
- Tested that it updates to xero invoice

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
