### PR TITLE
Put recurring workflows widget back to dashboard

### DIFF
--- a/app/controllers/symphony/home_controller.rb
+++ b/app/controllers/symphony/home_controller.rb
@@ -9,6 +9,7 @@ class Symphony::HomeController < ApplicationController
     @outstanding_actions = WorkflowAction.includes(:workflow).all_user_actions(current_user).where.not(completed: true).where.not(deadline: nil).where(company: @company).order(:deadline).includes(:task).count
     @batch_count = policy_scope(Batch).count
     @reminder_count = current_user.reminders.count
+    @recurring_count = current_user.company.recurring_workflows.all.count
     @s3_direct_post = S3_BUCKET.presigned_post(key: "uploads/#{SecureRandom.uuid}/${filename}", allow_any: ['utf8', 'authenticity_token'], success_action_status: '201', acl: 'public-read')
   end
 end

--- a/app/views/symphony/home/index.html.slim
+++ b/app/views/symphony/home/index.html.slim
@@ -18,6 +18,10 @@
           .card-body
            h5.card-title Reminders
            h1.card-text = link_to @reminder_count, symphony_reminders_path, class: 'text-dark'
+        .card.text-center.bg-light
+          .card-body
+           h5.card-title Recurring
+           h1.card-text = link_to @recurring_count, symphony_workflows_recurring_path, class: 'text-dark'
   .row
     .col-sm-6
       .card.mb-3
@@ -27,6 +31,15 @@
             = label_tag "template", "Select template:"
             = select_tag "template", options_from_collection_for_select(@templates, "slug", "title"), include_blank: true, class: "selectize", onchange: "$('#new-workflow').attr('href', '/symphony/' + $(this).val() + '/new')"
           = link_to 'New Workflow', '', class: 'btn btn-primary d-block mb-2', id: 'new-workflow'
+    .col-sm-6
+      .card.mb-3  
+        h5.card-header New Recurring Workflow 
+        .card-body  
+          .form-group 
+            = label_tag "template", "Select template:"  
+            = select_tag "template", options_from_collection_for_select(@templates, "slug", "title"), include_blank: true, class: "selectize", onchange: "$('#new-recurring-workflow').attr('href', '/symphony/recurring_workflows/' + $(this).val() + '/new')" 
+          = link_to 'New Recurring Workflow', '', class: 'btn btn-primary d-block mb-2', id: 'new-recurring-workflow'
+  .row
     .col-sm-6
       .card.mb-3
         h5.card-header Batch Upload


### PR DESCRIPTION
# Description
- Put recurring workflows and its function back. Modify layout with recurring workflows count

Trello link: https://trello.com/c/{card-id}

## Remarks
- nil

# Testing
- Test by looking at display and make sure redirection is correct

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
