### PR TITLE
Skip connect to xero if company already connected previously

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,7 +20,7 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(resource)
-    if current_user.company.connect_xero?
+    if current_user.company.session_handle.blank? and current_user.company.connect_xero?
       XeroSessionsController.connect_to_xero(session)
     else
       symphony_root_path


### PR DESCRIPTION
# Description

Urgent fix to bypass Xero connect if company has been connected to Xero previously.

Trello link: N/A

## Remarks

Nil

# Testing

Tried to login on Staging to make sure login does not return an error.

## Checklist:

- [ ] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code thoroughly
- [ ] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
