### PR TITLE
Retain function of tab key to move to next field in invoice date field

### DIFF
--- a/app/assets/javascripts/components/date_time_picker.js
+++ b/app/assets/javascripts/components/date_time_picker.js
@@ -6,7 +6,7 @@ function changeDateValue(dateStr){
   var dsplit = dateStr.split("-");
 
   // if year cannot detect, default year is current year
-  if (!dsplit[2]){  
+  if (!dsplit[2]){
     dsplit[2] = new Date().getFullYear();
   }
   // create the date
@@ -43,9 +43,9 @@ $(document).on("turbolinks:load", function() {
 
 
   //auto convert date
-  $('.autodate').keydown(function (event) {
+  $(".autodate").keydown(function (event) {
     // check if tab keyboard button pressed
-    if (event.keyCode == 9) {
+    if (event.keyCode === 9) {
       let dateStr = $(this).val();
       // do change the field value with date format
       $(this).val(changeDateValue(dateStr));


### PR DESCRIPTION
# Description

- Fix JS of date field move to next field when tab keyboard button pressed

Trello link: https://trello.com/c/lrm0ANsD

## Remarks

- No remarks

# Testing

- Testing on create/edit invoice page

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [x] I have added instructions and data required to test the code
- [x] I have tested the changes on the front-end on Chrome, Firefox and IE
