### PR TITLE
Fix admin option is missing for the company admin

### DIFF
--- a/app/views/layouts/dashboard/_header.html.slim
+++ b/app/views/layouts/dashboard/_header.html.slim
@@ -46,7 +46,7 @@
         li.nav-item
           = link_to "https://github.com/hschin/excide-manuscript/wiki", class: 'nav-link', target: :_blank do
             i.ti-help
-        - if current_user.has_role?(:admin, @company) or current_user.has_role?(:superadmin)
+        - if current_user.has_role?(:admin, current_user.company) or current_user.has_role?(:superadmin)
           li.nav-item.dropdown
             a.nav-link.dropdown-toggle href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" Admin
             .dropdown-menu


### PR DESCRIPTION
# Description

- Fix admin option is missing for the company admin

Trello link: https://trello.com/c/yGXLm27k

## Remarks

- none

# Testing

- For role company admin, it should display admin option on symphony dashboard

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
