### PR TITLE
Fix new activation popover body not show up

### DIFF
--- a/app/assets/javascripts/conductor/home.js
+++ b/app/assets/javascripts/conductor/home.js
@@ -15,6 +15,7 @@ $(document).on("turbolinks:load", function(){
   // Create new activation
   $('.new_activations').popover({
     html: true,
+    sanitize: false,
     container: 'body',
     placement: 'auto',
     content: function () {


### PR DESCRIPTION
# Description

- I disable sanitize option for popover content

Trello link: https://trello.com/c/zmrWz7EU

## Remarks

- none

# Testing

- The popover for new activation can show up, on conductor home page.

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [x] I have tested the changes on the front-end on Chrome, Firefox and IE
