### PR TITLE
Fix generate batch when create batch

### DIFF
--- a/app/controllers/symphony/batches_controller.rb
+++ b/app/controllers/symphony/batches_controller.rb
@@ -19,7 +19,7 @@ class Symphony::BatchesController < ApplicationController
   end
 
   def create
-    @template = Template.find(params[:batch][:template_id])
+    @template = Template.find_by(slug: params[:batch][:template_id])
     @generate_batch = GenerateBatch.new(current_user, @template).run
     authorize @generate_batch.batch
     respond_to do |format|

--- a/app/services/generate_batch.rb
+++ b/app/services/generate_batch.rb
@@ -7,6 +7,7 @@ class GenerateBatch
   def run
     begin
       generate_batch
+      @batch.save
       OpenStruct.new(success?: true, batch: @batch)
     rescue => e
       OpenStruct.new(success?: false, batch: @batch, message: e.message)
@@ -16,6 +17,9 @@ class GenerateBatch
   private
 
   def generate_batch
-    @batch = Batch.create(user: @user, template: @template, company: @user.company)
+    @batch = Batch.new
+    @batch.user = @user
+    @batch.template = @template
+    @batch.company = @user.company
   end
 end


### PR DESCRIPTION
# Description

Fix Generate batch structure, when batch have error it will redirect to new batch page and flash message about the error will appear

Trello link: https://trello.com/c/{card-id}

## Remarks

- No remarks

# Testing

- Testing on create new batch form

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [x] I have added instructions and data required to test the code
- [x] I have tested the changes on the front-end on Chrome, Firefox and IE
