### PR TITLE
Fix error input field when create batch

### DIFF
--- a/app/services/generate_batch.rb
+++ b/app/services/generate_batch.rb
@@ -18,8 +18,8 @@ class GenerateBatch
 
   def generate_batch
     @batch = Batch.new
-    @batch.user = @user
-    @batch.template = @template
-    @batch.company = @user.company
+    @batch.user_id = @user.id
+    @batch.template_id = @template.id
+    @batch.company_id = @user.company.id
   end
 end


### PR DESCRIPTION
# Description

Fix error when create batch
`PG::InsufficientPrivilege: ERROR: permission denied for relation batches : INSERT INTO "batches" ("company_id", "template_id", "created_at", "updated_at", "user_id") VALUES ($1, $2, $3, $4, $5) RETURNING "id"`

Trello link: https://trello.com/c/{card-id}

## Remarks

- No remarks

# Testing

- Testing on create batch

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [x] I have added instructions and data required to test the code
- [x] I have tested the changes on the front-end on Chrome, Firefox and IE
