### PR TITLE
Display users from role associate of company on index page

### DIFF
--- a/app/controllers/conductor/allocations_controller.rb
+++ b/app/controllers/conductor/allocations_controller.rb
@@ -138,7 +138,7 @@ class Conductor::AllocationsController < ApplicationController
   end
 
   def set_associate
-    @users = User.where(company: @company).with_role :associate, @company
+    @users = User.with_role(:associate, @company).uniq
   end
 
   def set_events

--- a/app/controllers/conductor/availabilities_controller.rb
+++ b/app/controllers/conductor/availabilities_controller.rb
@@ -101,7 +101,7 @@ class Conductor::AvailabilitiesController < ApplicationController
   end
 
   def set_associate
-    @users = User.where(company: @company).with_role :associate, @company
+    @users = User.with_role(:associate, @company).uniq
   end
 
   def set_time_header

--- a/app/controllers/conductor/users_controller.rb
+++ b/app/controllers/conductor/users_controller.rb
@@ -7,7 +7,7 @@ class Conductor::UsersController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update, :destroy]
 
   def index
-    @users = User.where(company: @company).with_role :associate, @company
+    @users = User.with_role(:associate, @company).uniq
   end
 
   def show
@@ -56,7 +56,7 @@ class Conductor::UsersController < ApplicationController
   end
 
   def export
-    @users = User.where(company: @company).with_role :associate, @company
+    @users = User.with_role(:associate, @company).uniq
     send_data @users.associates_to_csv, filename: "Associates-#{Date.current}.csv"
   end
 


### PR DESCRIPTION
# Description

Display users from role associate of company on index page

Trello link: https://trello.com/c/YLRw1kT1

## Remarks

- none

# Testing

- On conductor users index page, it should display users from role associate of company

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [x] I have tested the changes on the front-end on Chrome, Firefox and IE
