### PR TITLE
Fix/Unable to archive workflow

### DIFF
--- a/app/services/generate_archive.rb
+++ b/app/services/generate_archive.rb
@@ -7,7 +7,7 @@ class GenerateArchive
   def run
     begin
       @workflow.transaction do
-        @workflow.update_columns(completed: true, archive: generate_archive, completed_user_id: current_user.id)
+        @workflow.update_columns(completed: true, archive: generate_archive)
         delete_reminders
         remove_document_workflow_action_id
         delete_workflow_actions


### PR DESCRIPTION
# Description

Remove completed_user_id from generate_archive service which was added from this commit
https://github.com/hschin/excide/commit/5287e1e529932372a60877355aebb74d18b3f123#diff-adbecdfbd59642fe9073cb99c15c9dc3
Completed_user_id is for workflow_action, not workflow
Trello link: https://trello.com/c/MpMmVGTO

## Remarks

# Testing

Create workflow and archive both new and current workflows.

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
