### PR TITLE
Authorise all actions by superadmins by default

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -8,7 +8,7 @@ class ApplicationPolicy
   end
 
   def index?
-    false
+    user && user.has_role?(:superadmin) || false
   end
 
   def show?
@@ -16,7 +16,7 @@ class ApplicationPolicy
   end
 
   def create?
-    false
+    user && user.has_role?(:superadmin) || false
   end
 
   def new?
@@ -24,7 +24,7 @@ class ApplicationPolicy
   end
 
   def update?
-    false
+    user && user.has_role?(:superadmin) || false
   end
 
   def edit?
@@ -32,7 +32,7 @@ class ApplicationPolicy
   end
 
   def destroy?
-    false
+    user && user.has_role?(:superadmin) || false
   end
 
   def scope


### PR DESCRIPTION
# Description

Add a catch all to authorise superadmin for all actions in the base application policy.

Trello link: https://trello.com/c/sJknU5fE

## Remarks

None

# Testing

Check that all actions are available for superadmins.

## Checklist:

- [ ] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code thoroughly
- [ ] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
