### PR TITLE
Set company before get xero details

### DIFF
--- a/app/controllers/symphony/invoices_controller.rb
+++ b/app/controllers/symphony/invoices_controller.rb
@@ -3,7 +3,7 @@ class Symphony::InvoicesController < ApplicationController
   layout 'dashboard/application'
 
   before_action :authenticate_user!
-  before_action :set_company, except: [:get_xero_item_code_detail]
+  before_action :set_company
   before_action :set_workflow, except: [:get_xero_item_code_detail]
   before_action :set_workflows_navigation, only: [:new, :create, :edit]
   before_action :set_documents, except: [:get_xero_item_code_detail]


### PR DESCRIPTION
# Description

Set company before get xero details

Trello link: https://trello.com/c/YC215eBR

## Remarks

- None

# Testing

- On invoice page (edit/new), after selected item (dropdown), it should work properly without show error.

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [x] I have tested the changes on the front-end on Chrome, Firefox and IE
