### PR TITLE
Fix to get xero contact id when approve invoice

### DIFF
--- a/app/controllers/symphony/workflows_controller.rb
+++ b/app/controllers/symphony/workflows_controller.rb
@@ -255,7 +255,7 @@ class Symphony::WorkflowsController < ApplicationController
       @invoice_payable.save
     else
       #in future if we do account receivable, must modify the adapter method create_invoice_receivable
-      @invoice = @xero.create_invoice_receivable(@workflow.workflowable.xero_contact_id, @workflow.invoice.invoice_date, @workflow.invoice.due_date, "EXCIDE")
+      @invoice = @xero.create_invoice_receivable(@workflow.invoice.xero_contact_id, @workflow.invoice.invoice_date, @workflow.invoice.due_date, "EXCIDE")
     end
 
     respond_to do |format|


### PR DESCRIPTION
# Description

Fix get xero contact id when approve (`xero_create_invoice_payable`)

Trello link: https://trello.com/c/{card-id}

## Remarks

- No remarks

# Testing

- Testing on approve invoice

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [x] I have added instructions and data required to test the code
- [x] I have tested the changes on the front-end on Chrome, Firefox and IE
