### PR TITLE
Update and install gem for csrf protection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,8 @@ gem 'rolify'
 gem 'pundit'
 # LinkedIn API integration
 gem 'omniauth'
-gem 'omniauth-oauth2', '~> 1.3.1'
+gem 'omniauth-rails_csrf_protection'
+gem 'omniauth-oauth2'
 gem 'omniauth-linkedin-oauth2'
 # Xero API integration for partner app
 gem 'xeroizer', git: 'https://github.com/waynerobinson/xeroizer.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,14 +15,14 @@ GIT
 
 GIT
   remote: https://github.com/stympy/faker.git
-  revision: d8e48fa0f49321780e930a6f17889fa2282949dc
+  revision: a1c672930811d6bf71ce522c522bc255c345a6b8
   specs:
-    faker (2.7.0)
+    faker (2.8.1)
       i18n (>= 1.6, < 1.8)
 
 GIT
   remote: https://github.com/waynerobinson/xeroizer.git
-  revision: ccb15250b868dd5bdb9d327f8984f212abe18504
+  revision: f4305755cff79072cea6d5eef357c16a00f922cb
   specs:
     xeroizer (3.0.0.pre.beta)
       activesupport
@@ -119,16 +119,16 @@ GEM
       algoliasearch (>= 1.26.0, < 2.0.0)
       json (>= 1.5.1)
     ast (2.4.0)
-    autoprefixer-rails (9.7.1)
+    autoprefixer-rails (9.7.3)
       execjs
     aws-eventstream (1.0.3)
-    aws-sdk (2.11.398)
-      aws-sdk-resources (= 2.11.398)
-    aws-sdk-core (2.11.398)
+    aws-sdk (2.11.412)
+      aws-sdk-resources (= 2.11.412)
+    aws-sdk-core (2.11.412)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.398)
-      aws-sdk-core (= 2.11.398)
+    aws-sdk-resources (2.11.412)
+      aws-sdk-core (= 2.11.412)
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
     bcrypt (3.1.13)
@@ -139,7 +139,7 @@ GEM
     bindex (0.8.1)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
-    bootstrap (4.3.1)
+    bootstrap (4.4.1)
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 1.14.3, < 2)
       sassc-rails (>= 2.0.0)
@@ -147,7 +147,7 @@ GEM
       jquery-rails (~> 4.2, >= 4.2.0)
       moment-timezone-rails (~> 1.0)
       momentjs-rails (>= 2.10.5, <= 3.0.0)
-    brakeman (4.7.1)
+    brakeman (4.7.2)
     builder (3.2.3)
     bullet (6.0.2)
       activesupport (>= 3.0.0)
@@ -160,7 +160,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.5)
-    css_parser (1.7.0)
+    css_parser (1.7.1)
       addressable
     datetime_picker_rails (0.0.7)
       momentjs-rails (>= 2.8.1)
@@ -182,16 +182,16 @@ GEM
       dotenv (= 2.7.5)
       railties (>= 3.2, < 6.1)
     erubi (1.9.0)
-    excon (0.68.0)
+    excon (0.70.0)
     execjs (2.7.0)
     factory_bot (5.1.1)
       activesupport (>= 4.2.0)
     factory_bot_rails (5.1.1)
       factory_bot (~> 5.1.0)
       railties (>= 4.2.0)
-    faraday (0.17.0)
+    faraday (0.17.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.11.2)
+    ffi (1.11.3)
     fog-aws (3.5.2)
       fog-core (~> 2.1)
       fog-json (~> 1.1)
@@ -265,7 +265,7 @@ GEM
       activerecord
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
-    listen (3.2.0)
+    listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     lograge (0.11.2)
@@ -273,7 +273,7 @@ GEM
       activesupport (>= 4)
       railties (>= 4)
       request_store (~> 1.0)
-    loofah (2.3.1)
+    loofah (2.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.13)
@@ -291,14 +291,14 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.13.0)
-    mixpanel-ruby (2.2.1)
+    mixpanel-ruby (2.2.2)
     moment-timezone-rails (1.0.0)
       momentjs-rails (>= 2.10.5, <= 3.0.0)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
     monetize (1.9.2)
       money (~> 6.12)
-    money (6.13.4)
+    money (6.13.6)
       i18n (>= 0.6.4, <= 2)
     money-rails (1.13.3)
       activesupport (>= 3.0)
@@ -310,7 +310,7 @@ GEM
     multipart-post (2.1.1)
     nenv (0.3.0)
     nio4r (2.5.2)
-    nokogiri (1.10.5)
+    nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -322,17 +322,20 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    oj (3.9.2)
+    oj (3.10.0)
     omniauth (1.9.0)
       hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
     omniauth-linkedin-oauth2 (1.0.0)
       omniauth-oauth2
-    omniauth-oauth2 (1.3.1)
-      oauth2 (~> 1.0)
-      omniauth (~> 1.2)
+    omniauth-oauth2 (1.6.0)
+      oauth2 (~> 1.1)
+      omniauth (~> 1.9)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     orm_adapter (0.5.0)
-    parallel (1.19.0)
+    parallel (1.19.1)
     parser (2.6.5.0)
       ast (~> 2.4.0)
     pg (1.1.4)
@@ -361,7 +364,7 @@ GEM
       i18n (>= 0.5.0)
       railties (>= 3.0.0)
     public_suffix (4.0.1)
-    puma (4.3.0)
+    puma (4.3.1)
       nio4r (~> 2.0)
     pundit (2.1.0)
       activesupport (>= 3.0.0)
@@ -458,7 +461,7 @@ GEM
     rspec-support (3.9.0)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (0.76.0)
+    rubocop (0.77.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
@@ -529,7 +532,7 @@ GEM
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
     squasher (0.6.2)
-    stripe (5.8.0)
+    stripe (5.11.0)
     sucker_punch (2.1.2)
       concurrent-ruby (~> 1.0)
     temple (0.8.2)
@@ -541,7 +544,7 @@ GEM
     turbolinks (5.1.1)
       turbolinks-source (~> 5.1)
     turbolinks-source (5.2.0)
-    twilio-ruby (5.29.1)
+    twilio-ruby (5.30.0)
       faraday (~> 0.9)
       jwt (>= 1.5, <= 2.5)
       nokogiri (>= 1.6, < 2.0)
@@ -562,14 +565,14 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webpacker (4.2.0)
+    webpacker (4.2.2)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
       railties (>= 4.2)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
-    zeitwerk (2.2.1)
+    zeitwerk (2.2.2)
 
 PLATFORMS
   ruby
@@ -613,7 +616,8 @@ DEPENDENCIES
   oj
   omniauth
   omniauth-linkedin-oauth2
-  omniauth-oauth2 (~> 1.3.1)
+  omniauth-oauth2
+  omniauth-rails_csrf_protection
   pg (>= 0.18, < 2.0)
   popper_js
   premailer-rails


### PR DESCRIPTION
# Description

Install gem that provides mitigation against CVE-2015-9284 (Cross-Site Request Forgery on the request phase when using OmniAuth gem with a Ruby on Rails application) by implementing a CSRF token verifier that directly uses ActionController::RequestForgeryProtection code from Rails.

## Remarks

Omniauth is present because of LinkedIn login previously but not actively being used at the moment.

# Testing

Make sure app still functions as normal, especially user authentication functions.

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [x] I have added instructions and data required to test the code
- [x] I have tested the changes on the front-end on Chrome, Firefox and IE
