### PR TITLE
Fix/workflow upload file

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -133,6 +133,7 @@ class Workflow < ApplicationRecord
       s.tasks.each do |t|
         WorkflowAction.create!(task: t, completed: false, company: self.company, workflow: self)
       end
+      # Automatically set first task as completed if workflow is part of a batch and first task is a file upload task
       s.tasks.first.get_workflow_action(self.company_id, self.id).update(completed: true) if (s.position == 1 && s.tasks.first.task_type == "upload_file" && self.batch.present?)
     end
     if ordered_workflow?


### PR DESCRIPTION
# Description

Previously there was an error when creating workflow with "upload_file" as first task, days to complete and reminder set to true. This is due to creating a workflow action with completed: true and because of this code
after_save :trigger_next_task, if: :ordered_workflow_task_completed?
It will attempt to trigger next task when the next workflow action has not been created yet.

I changed the order such that all the workflow actions are created with completed:false first. It will be updated to true afterwards.

Trello link: https://trello.com/c/rxk6smZI

## Remarks

# Testing

Create workflow with template with "upload_file" as first task, days to complete and reminder set to true.
Create batch

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
