### PR TITLE
Remove require tree `landing` folder in application scss

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,7 +12,6 @@
  *
  *= require trix
  *= require_self
- *= require_tree ./landing
  */
 
 @import "bootstrap";


### PR DESCRIPTION
# Description

After i removed the `landing` folder, i forgot to remove the line `require_tree ./landing`, in this pull request i removed it

Trello link: https://trello.com/c/{card-id}

## Remarks

[Are there any issues to take note of? For example, anything that might cause problems or any code that can be refactored in the future.]

# Testing

[Please describe the tests that you used to verify your changes. Provide instructions so that the tests can be reproduced.]

## Checklist:

- [ ] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [x] I have tested the changes on the front-end on Chrome, Firefox and IE
