### PR TITLE
Fix parameter name of field xero_connect in additonal information form

### DIFF
--- a/app/views/users/registrations/additional_information.html.slim
+++ b/app/views/users/registrations/additional_information.html.slim
@@ -42,7 +42,7 @@ section.height-100.imagebg data-overlay="4"
                     = fc.text_field :name, class: 'form-control', required: true
                   .col-md-12
                     .input-checkbox
-                      input#input-assigned-8 name="connect_xero" type="checkbox"
+                      = fc.check_box :connect_xero, {class: "input-assigned-8"}
                       label for="input-assigned-8"
                     span Connect Xero
                   .col-md-12


### PR DESCRIPTION
# Description

- Fix parameter name should of field xero_connect in additional information form

Trello link: https://trello.com/c/5w9bJk4R

## Remarks

- none

# Testing

- After user sign up, in additional information page fill all the fields and don't tick the checkbox `connect xero`
- Save Additional Information, It should redirect to symphony dashboard to create a new template

## Checklist:

- [ ] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [x] I have tested the changes on the front-end on Chrome, Firefox and IE
