### PR TITLE
Batch upload error in metronic

### DIFF
--- a/app/javascript/src-dashboard/components/multiple_uploads.js
+++ b/app/javascript/src-dashboard/components/multiple_uploads.js
@@ -130,16 +130,16 @@ $(document).on("turbolinks:load", function() {
     documentUpload.on("queuecomplete", () => {
       // Create workflows from multiple files
       $.each(documentUpload["files"], (index, file) => {
-        getUrlResponse = $.parseXML(file["xhr"]["response"]);
-        $(getUrlResponse).find("Location").text();
+        responseURL = file["xhr"]["responseURL"].replace(/^https?:/,'');
+        responseKey = $($.parseXML(file["xhr"]["response"])).find("Key").text();
         let data_input = {
           authenticity_token: $.rails.csrfToken(),
           document_type: 'batch-uploads',
           batch_id: batchId,
           count: documentUpload["files"].length,
           document: {
-            filename: file.upload.filename,
-            file_url: $(getUrlResponse).find("Location").text().replace(/^https?:/,''),
+            filename: file.name,
+            file_url: responseURL + responseKey,
             template_id: $('#template_id').val()
           }
         };


### PR DESCRIPTION
# Description

- I use `queuecomplete` event of Dropzone. So after all the files are finish uploaded, it will create workflows from multiple files for the batch.

Trello link: https://trello.com/c/qem2jO1N

## Remarks

- none

# Testing

- Create new batch with different size of file, select template and submit
- When all files are finish uploaded, the page will redirect to the batch page

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [ ] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [x] I have tested the changes on the front-end on Chrome, Firefox and IE
