### PR TITLE
Fix load file datetimepicker should from node modules

### DIFF
--- a/app/assets/stylesheets/application-dashboard.scss
+++ b/app/assets/stylesheets/application-dashboard.scss
@@ -22,7 +22,6 @@
 @import "bootstrap";
 @import "themify-icons";
 @import "font-awesome";
-@import "tempusdominus-bootstrap-4";
 @import "simple_calendar";
 @import "symphony/invoices";
 @import "symphony/batches";

--- a/app/javascript/packs/application-dashboard.js
+++ b/app/javascript/packs/application-dashboard.js
@@ -19,5 +19,6 @@ require("turbolinks").start()
 
 import 'bootstrap/dist/js/bootstrap';
 import 'dropzone/dist/dropzone';
+import 'tempusdominus-bootstrap-4/build/css/tempusdominus-bootstrap-4.min';
 import '../src-dashboard/application.js';
 import '../src-dashboard/metronic/application.js';


### PR DESCRIPTION
# Description

I did removed the datetimepicker from gemfile, and installed it in webpacker. I fixed by remove datetimepicker from assets in file application.css, and call it on webpack.

Trello link: 
rollbar https://rollbar.com/excide-staging/excide-staging/items/334/

## Remarks

- none

# Testing

- For the fields of datetimepicker, the fields should has styles. (the styles loaded from webpack)

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [x] I have tested the changes on the front-end on Chrome, Firefox and IE
