### PR TITLE
Update existing companies to PRO account

### DIFF
--- a/lib/tasks/update.rake
+++ b/lib/tasks/update.rake
@@ -47,7 +47,7 @@ namespace :update do
 
   desc "Update all existing companies to PRO account if account type is nil"
   task update_existing_companies_to_pro: :environment do
-    Company.all.where(account_type: nil).each do |company|
+    Company.where(account_type: nil).each do |company|
       company.upgrade
       company.save
     end


### PR DESCRIPTION
# Description
Rake task to update all existing companies to PRO account if their account_type is nil.
Run `rake update:update_existing_companies_to_pro` to update existing companies to PRO.

Trello link: https://trello.com/c/MUYP2ibg

## Remarks
- When user cancels subscription, error will occur as plan data is empty.

# Testing
- Tested PRO features work
- Checked that all existing companies changed to PRO type account.

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [x] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
