### PR TITLE
Fix invoice send twice on stripe webhook

### DIFF
--- a/app/services/stripe/event_handler.rb
+++ b/app/services/stripe/event_handler.rb
@@ -40,7 +40,7 @@ module Stripe
     def handle_invoice_payment_succeeded(event)
       @current_user = User.find_by(stripe_customer_id: event.data.object.customer)
       subscription = Stripe::Subscription.retrieve(event.data.object.subscription)
-      invoice = Stripe::Invoice.retrieve(subscription['latest_invoice'])
+      invoice = Stripe::Invoice.retrieve(event.data.object.id)
       period_start = subscription["current_period_start"]
       period_end = subscription["current_period_end"]
       invoice_pdf = event.data.object["invoice_pdf"]


### PR DESCRIPTION
# Description
Bugfix: Duplicate condition didnt check for stripe webhook sending multiple time.
Change invoice to retrieve from webhook event (event.data.object.id) instead of subscription['latest_invoice'] for a more accurate use of webhook

Trello link: https://trello.com/c/{card-id}

## Remarks
- Nil

# Testing
- Checkout payment event and invoice payment succeeded calls back without error.

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
