### PR TITLE
Bugfix/Stripe invoice sent back twice

### DIFF
--- a/app/services/stripe/event_handler.rb
+++ b/app/services/stripe/event_handler.rb
@@ -48,7 +48,7 @@ module Stripe
       # This codes updates the stripe subscription plan data in DB upon recurring biling from Stripe. The if-condition checks for it being recurring (there should be subscription plan data rather than an empty array). 
       @current_user.company.stripe_subscription_plan_data['subscription'] = subscription
       # Check for no duplicate invoices in the database, in case webhook send back twice the response
-      @current_user.company.stripe_subscription_plan_data['invoices'].push( invoice ) if @current_user.company.stripe_subscription_plan_data['invoices'].any?{|inv| inv['id'] != invoice.id }
+      @current_user.company.stripe_subscription_plan_data['invoices'].push( invoice ) if @current_user.company.stripe_subscription_plan_data['invoices'].all?{|inv| inv['id'] != invoice.id }
       @current_user.company.save
 
       # Send email to inform user that payment is successful.


### PR DESCRIPTION
# Description
Changed condition from any? to all? so that it will check all the arrays and if all are not eql to the stripe invoice id, then it returns true.

Trello link: https://trello.com/c/{card-id}

## Remarks

[Are there any issues to take note of? For example, anything that might cause problems or any code that can be refactored in the future.]

# Testing

[Please describe the tests that you used to verify your changes. Provide instructions so that the tests can be reproduced.]

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
