### PR TITLE
Only sent out email upon no duplicate invoice

### DIFF
--- a/app/services/stripe/event_handler.rb
+++ b/app/services/stripe/event_handler.rb
@@ -64,11 +64,13 @@ module Stripe
       # This codes updates the stripe subscription plan data in DB upon recurring biling from Stripe. The if-condition checks for it being recurring (there should be subscription plan data rather than an empty array). 
       @current_user.company.stripe_subscription_plan_data['subscription'] = subscription
       # Check for no duplicate invoices in the database, in case webhook send back twice the response
-      @current_user.company.stripe_subscription_plan_data['invoices'].push( invoice ) if @current_user.company.stripe_subscription_plan_data['invoices'].all?{|inv| inv['id'] != invoice.id }
-      @current_user.company.save
+      if @current_user.company.stripe_subscription_plan_data['invoices'].all?{|inv| inv['id'] != invoice.id }
+        @current_user.company.stripe_subscription_plan_data['invoices'].push( invoice )
+        @current_user.company.save
 
-      # Send email to inform user that payment is successful.
-      StripeNotificationMailer.payment_successful(@current_user, period_start, period_end, invoice_pdf).deliver_later
+        # Send email to inform user that payment is successful.
+        StripeNotificationMailer.payment_successful(@current_user, period_start, period_end, invoice_pdf).deliver_later
+      end
     end
 
     def handle_charge_failed(event)


### PR DESCRIPTION
# Description
Send out email even when webhook error. 
Solution: put mailer method within the condition block

Trello link: https://trello.com/c/{card-id}

## Remarks
- nil

# Testing

[Please describe the tests that you used to verify your changes. Provide instructions so that the tests can be reproduced.]

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
