### PR TITLE
Bugfix - Form validates removed tasks

### DIFF
--- a/app/javascript/src-dashboard/symphony.js
+++ b/app/javascript/src-dashboard/symphony.js
@@ -37,8 +37,8 @@ $(document).on("turbolinks:load", function(){
     $(this).prev('input[type=hidden]').val('1');
     $(this).closest('tr').hide();
     // Remove all the required validation to skip html5 validation error
-    $(this).closest('tr').find('td input').removeAttr('required')
-    $(this).closest('tr').find('td textarea').removeAttr('required')
+    $(this).closest('tr').find('td input').removeAttr('required');
+    $(this).closest('tr').find('td textarea').removeAttr('required');
     return event.preventDefault();
   })
 


### PR DESCRIPTION
# Description
1. When remove tasks, it hides the table form row instead of removing it. Chrome/firefox built-in validator will validate the form when it is required: true, hence returning an error: An invalid form control with name= is not focusable.
- The solution is to remove all disabled true of the hidden fields, so that validation wont occur.

2. Fix selectize for the tasks dropdown items.

Trello link: https://trello.com/c/3sAtq8g1

## Remarks
- Feels like a hack. Normal validation still works though, as I only remove the hidden element's validation

# Testing
- Tested by adding tasks, removed it and submit form. Doesn't return js error.
- Tested by creating templates, with different sections and many tasks. Checked that deleting tasks works accurately and checked that chrome/firefox built-in validator doesn't prompt error when user add and then remove tasks.
- Tested on both Chrome and firefox

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [x] I have tested the changes on the front-end on Chrome, Firefox and IE
