### PR TITLE
Enable action cable in activity_notification gem for deploying to production

### DIFF
--- a/config/initializers/activity_notification.rb
+++ b/config/initializers/activity_notification.rb
@@ -69,17 +69,17 @@ ActivityNotification.configure do |config|
   # Configure if WebSocket subscription using ActionCable is enabled.
   # Note that you can configure them for each model by acts_as roles.
   # Set true when you want to turn on WebSocket subscription using ActionCable as default.
-  config.action_cable_enabled = false
+  config.action_cable_enabled = true
 
   # Configure if WebSocket API subscription using ActionCable is enabled.
   # Note that you can configure them for each model by acts_as roles.
   # Set true when you want to turn on WebSocket API subscription using ActionCable as default.
-  config.action_cable_api_enabled = false
+  config.action_cable_api_enabled = true
 
   # Configure if ctivity_notification publishes WebSocket notifications using ActionCable only to authenticated target with Devise.
   # Note that you can configure them for each model by acts_as roles.
   # Set true when you want to use Device integration with WebSocket subscription using ActionCable as default.
-  config.action_cable_with_devise = false
+  config.action_cable_with_devise = true
 
   # Configure notification channel prefix for ActionCable.
   config.notification_channel_prefix = 'activity_notification_channel'


### PR DESCRIPTION
# Description
Error occurs when deploying activity_notification gem to staging. 
Error from heroku logs:
![Screenshot 2020-03-24 at 3 19 13 PM](https://user-images.githubusercontent.com/40416736/77401134-563e0700-6de7-11ea-9811-c605244f088c.png)

Checking the source code, the constant ActivityNotification::NotificationChannel is only define when action cable is enabled.
![Screenshot 2020-03-24 at 3 47 10 PM](https://user-images.githubusercontent.com/40416736/77401224-7f5e9780-6de7-11ea-8fcb-fe283d1167f2.png)

This PR is to enable action cable to bypass the error.

Trello link: https://trello.com/c/{card-id}

## Remarks
- Production error only though. Development works completely well for some reason

# Testing
- Tested that development in-app notification function still works

## Checklist:

- [ ] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
