### PR TITLE
Revert "Enable action cable in activity_notification gem for deploying to production"

### DIFF
--- a/config/initializers/activity_notification.rb
+++ b/config/initializers/activity_notification.rb
@@ -69,17 +69,17 @@ ActivityNotification.configure do |config|
   # Configure if WebSocket subscription using ActionCable is enabled.
   # Note that you can configure them for each model by acts_as roles.
   # Set true when you want to turn on WebSocket subscription using ActionCable as default.
-  config.action_cable_enabled = true
+  config.action_cable_enabled = false
 
   # Configure if WebSocket API subscription using ActionCable is enabled.
   # Note that you can configure them for each model by acts_as roles.
   # Set true when you want to turn on WebSocket API subscription using ActionCable as default.
-  config.action_cable_api_enabled = true
+  config.action_cable_api_enabled = false
 
   # Configure if ctivity_notification publishes WebSocket notifications using ActionCable only to authenticated target with Devise.
   # Note that you can configure them for each model by acts_as roles.
   # Set true when you want to use Device integration with WebSocket subscription using ActionCable as default.
-  config.action_cable_with_devise = true
+  config.action_cable_with_devise = false
 
   # Configure notification channel prefix for ActionCable.
   config.notification_channel_prefix = 'activity_notification_channel'


### PR DESCRIPTION
Reverts hschin/excide#537