### PR TITLE
Fix outstanding task count and display

### DIFF
--- a/app/controllers/symphony/home_controller.rb
+++ b/app/controllers/symphony/home_controller.rb
@@ -17,7 +17,7 @@ class Symphony::HomeController < ApplicationController
     end
     @workflows = Kaminari.paginate_array(templates_type).page(params[:page]).per(5)
 
-    @outstanding_actions = WorkflowAction.includes(:workflow).all_user_actions(current_user).where.not(completed: true).where.not(deadline: nil).where(company: @company).order(:deadline).includes(:task)
+    @outstanding_actions = WorkflowAction.includes(:workflow).all_user_actions(current_user).where.not(completed: true).where.not(deadline: nil).where(company: current_user.company).order(:deadline).includes(:task)
 
     @batch_count = policy_scope(Batch).count
     @reminder_count = current_user.reminders.where(company: current_user.company).count


### PR DESCRIPTION
# Description
Task was always 0 and outstanding actions message wasn't displayed.
- Company wasn't defined

Trello link: https://trello.com/c/EicULquw

## Remarks
- Nil

# Testing
- Check that outstanding task activities matches the count

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
