### PR TITLE
BugFix - Fix unable to find ID on stripe webhook

### DIFF
--- a/app/services/stripe/event_handler.rb
+++ b/app/services/stripe/event_handler.rb
@@ -58,10 +58,9 @@ module Stripe
           @current_user.company.save
           # Assuming customer_subscription_updated method only runs upon clicking the cancellation button
           StripeNotificationMailer.cancel_subscription_notification(@current_user, period_end).deliver_later
-        elsif event.data.object.plan.id == ENV['STRIPE_ANNUAL_PLAN']
-          # only update to subscription plan data if it's annual plan
-          @current_user.company.stripe_subscription_plan_data['subscription'] = @subscription
         end
+        # only update to subscription plan data if it's annual plan
+        @current_user.company.stripe_subscription_plan_data['subscription'] = @subscription if event.data.object.plan.id == ENV['STRIPE_ANNUAL_PLAN']
         @current_user.company.save
       end
     end


### PR DESCRIPTION
# Description
Error on production:
#387 New error: NoMethodError: undefined method `id' for nil:NilClass

Reason: 
Webhook sending back users from other product. Hence, the user cannot be found in Symphony's database

Refactor some of the variables into the conditional block

Trello link: https://trello.com/c/{card-id}

## Remarks
- Test on staging

# Testing
- Cannot download Ngrok for some reason on windows linux subsystem.

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code thoroughly
- [ ] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
