### PR TITLE
Workflows index pagination bar moved to bottom

### DIFF
--- a/app/views/symphony/workflows/index.html.slim
+++ b/app/views/symphony/workflows/index.html.slim
@@ -27,4 +27,4 @@
                         td = w.remarks || '-'
                         td = w.deadline&.strftime("%d/%m/%Y") || '-'
                         td = w.completed ? 'Completed' : w.current_section&.section_name
-                  = paginate @workflows, views_prefix: 'dashboard'
+                = paginate @workflows, views_prefix: 'dashboard'


### PR DESCRIPTION
# Description

Decrease indentation so that pagination bar is now at the bottom. (same as batches)

Notion link: https://www.notion.so/Workflows-page-pagination-bar-should-be-at-the-bottom-of-the-table-84bccf53c7b34ed3983e39339968e2b9

## Remarks


# Testing

Pagination bar works fine.

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
