### PR TITLE
Fix/delete-uploaded-documents

### DIFF
--- a/app/controllers/symphony/documents_controller.rb
+++ b/app/controllers/symphony/documents_controller.rb
@@ -130,7 +130,7 @@ class Symphony::DocumentsController < ApplicationController
     authorize @document
 
     if @document.destroy
-      redirect_to symphony_documents_path
+      redirect_back fallback_location: symphony_documents_path
       respond_to do |format|
         format.html { redirect_to symphony_document_path, notice: 'Document was successfully deleted.' }
         format.js  { flash[:notice] = 'Document was successfully deleted.' }


### PR DESCRIPTION
# Description

Upon deletion of document, redirect_back to current page instead of symphony_documents_path.

Notion link: https://www.notion.so/Allow-deleting-of-uploaded-files-in-workflows-34373514aa1741c78d7a5fcd3b0a84e9

## Remarks

# Testing

Delete documents.

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
