### PR TITLE
Bring back IMPORTANT task feature by importing the css

### DIFF
--- a/app/webpacker/src/stylesheets/metronic/application.scss
+++ b/app/webpacker/src/stylesheets/metronic/application.scss
@@ -27,6 +27,7 @@
 @import "../src/stylesheets/metronic/css/companies";
 @import "../src/stylesheets/metronic/css/templates";
 @import "../src/stylesheets/metronic/css/pagination";
+@import "../src/stylesheets/metronic/css/workflows";
 @import "../src/stylesheets/metronic/pages/pricing/pricing-1";
 @import "../src/stylesheets/dashboard/admin";
 @import "../src/stylesheets/metronic/actiontext";


### PR DESCRIPTION
# Description
- IMPORTANT feature to highlight important task is missing
- Think it was missed out when moving to webpacker

Notion link: https://www.notion.so/{unique-id}

## Remarks
- Nil

# Testing
- Checked that important task is highlighted in both workflow and batch

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
