### PR TITLE
Fix change company layout for users with multiple admin roles

### DIFF
--- a/app/views/layouts/metronic/_header.html.slim
+++ b/app/views/layouts/metronic/_header.html.slim
@@ -28,7 +28,8 @@
                   - else
                     - Company.assigned_companies(current_user).sort_by{|c| c.created_at}.each do |company|
                       - if company.name.present?
-                        = link_to company.name, change_company_symphony_user_path(current_user, user: {company_id: company.id }), method: 'patch', class: 'kt-nav__link', tabindex: -1
+                        li.kt-nav__item
+                          = link_to company.name, change_company_symphony_user_path(current_user, user: {company_id: company.id }), method: 'patch', class: 'kt-nav__link', tabindex: -1
             - else
               = link_to(symphony_root_path, class: "btn btn-pill btn-default") do
                 ' #{current_user.company.name}


### PR DESCRIPTION
# Description
Change company dropdown layout companies were not split into rows, for users with admin role with different companies but not superadmin 

Notion link: https://www.notion.so/Layout-for-change-company-when-user-has-multiple-admin-account-but-is-not-superadmin-42cf234ad34b40c2b53c0c2b2e2fd354

## Remarks
- Nil

# Testing
- Tested with an account that had no superadmin role yet have multiple companies
- Checked that layout is ok for change company

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
