### PR TITLE
POST account code with any digit to Xero

### DIFF
--- a/app/adapters/adapter.rb
+++ b/app/adapters/adapter.rb
@@ -123,7 +123,8 @@ module Adapter
       end
       line_items.each do |line_item|
         tracking = [{name: tracking_name[0]&.name, option: line_item.tracking_option_1}, {name: tracking_name[1]&.name, option: line_item.tracking_option_2}]
-        inv.add_line_item(item_code: nil, description: line_item.description, quantity: line_item.quantity, unit_amount: line_item.price, account_code: line_item.account.split("-")[0], tax_type: line_item.tax.split.last, tracking: tracking)
+        # The strip method is called to remove whitespaces
+        inv.add_line_item(item_code: nil, description: line_item.description, quantity: line_item.quantity, unit_amount: line_item.price, account_code: line_item.account.split("-")[0].strip, tax_type: line_item.tax.split.last, tracking: tracking)
       end
       inv.save
       return inv
@@ -132,7 +133,7 @@ module Adapter
     def updating_invoice_payable(xero_invoice, updated_line_items)
       #update line item with the rounding line item
       rounding_line_item = updated_line_items.last
-      xero_invoice.add_line_item(item_code: nil, description: rounding_line_item.description, quantity: rounding_line_item.quantity, unit_amount: rounding_line_item.price, account_code: rounding_line_item.account&.split("-")[0]), tax_type: rounding_line_item.tax&.split&.last, tracking: nil)
+      xero_invoice.add_line_item(item_code: nil, description: rounding_line_item.description, quantity: rounding_line_item.quantity, unit_amount: rounding_line_item.price, account_code: rounding_line_item.account&.split("-")[0].strip, tax_type: rounding_line_item.tax&.split&.last, tracking: nil)
       xero_invoice.save
     end
   end


### PR DESCRIPTION
# Description
Currently the account code slices the first 3 digit from the account(string) in the invoice's line items.
Solution:
- Symphony stores account code in the format of (EG. 201 - Sales). Now I split the account code and the name with the dash as the indicator. Then I used the strip method from ruby to remove any whitespaces. 

Notion link: https://www.notion.so/Bug-Cannot-send-invoice-correctly-is-account-code-is-4-digit-c427c43a602b47edbece504f0c7257f9

## Remarks
- Nil

# Testing
- try to replicate the error by creating an account code of 4 digits like 5001. Xero will only find the 500 account code, which then returns blank because 500 doesn't exist.
- Try sending invoice to xero with 4 digits account code and 7-digits acc code (LOL!) and it works

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
