### PR TITLE
Fix routing to not use the @batch variable

### DIFF
--- a/app/controllers/symphony/documents_controller.rb
+++ b/app/controllers/symphony/documents_controller.rb
@@ -66,7 +66,7 @@ class Symphony::DocumentsController < ApplicationController
           workflow_action = WorkflowAction.find(params[:workflow_action])
           if workflow_action.update_attributes(completed: true, completed_user_id: current_user.id)
             # If batch is present, redirect to batch page, else go to workflow page
-            @batch.present? ? format.html {redirect_to symphony_batch_path(batch_template_name: @batch.template.slug, id: @batch.id)} : format.html{ redirect_to symphony_workflow_path(@batch.template.slug, workflow_action.workflow.id) } 
+            @batch.present? ? format.html {redirect_to symphony_batch_path(batch_template_name: @batch.template.slug, id: @batch.id)} : format.html{ redirect_to symphony_workflow_path(workflow_action.workflow.template.slug, workflow_action.workflow.id) } 
             flash[:notice] = "#{workflow_action.task.instructions} done!"
           else
             format.json { render json: workflow_action.errors, status: :unprocessable_entity }


### PR DESCRIPTION
# Description
- When upload file task in workflow, the routing still depends on the `@batch.template` variable (which is nil cause no batches in workflow task).
- Change to `workflow_action.workflow.template`

Notion link: https://www.notion.so/{unique-id}

## Remarks
- Nil

# Testing
- Tested the routing on localhost

## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
