### PR TITLE
Fix conversion by adding density so that text can be readable

### DIFF
--- a/app/services/conversion_service.rb
+++ b/app/services/conversion_service.rb
@@ -1,6 +1,7 @@
 class ConversionService
   # This service is to convert things. Eg PDF document converts to images
   require "mini_magick"
+
   def initialize(document)
     @document = document
   end
@@ -21,7 +22,7 @@ class ConversionService
       url = @document.raw_file.service_url
       page_count = MiniMagick::Image.open(url).pages.count
       page_count.times do |page_number|
-        result = ImageProcessing::MiniMagick.source(url).loader(page: page_number).append("-density", 300).append("-flatten").append("-quality", 90).convert("png").call
+        result = ImageProcessing::MiniMagick.source(url).loader(page: page_number, density: 100).convert("png").call
         @document.converted_images.attach(io: result, filename: result.path.split('/').last, content_type: "image/png")
       end
     end


### PR DESCRIPTION
# Description
Some PDF's text (which are usually very small like 10+kb) cannot be read due to conversion.
- Fix by adding density to it

Notion link: https://www.notion.so/Improve-image-quality-of-uploaded-files-74100eaa19774b4495fc75dafc1226bc

## Remarks
- Density only kept at 100. Initially added better quality but the processing became too slow (request timeout), hence left out quality to default one.

# Testing
- test batch upload with AP workflow and check the new converted image 
<img width="395" alt="Screenshot 2020-06-04 at 10 07 29 PM" src="https://user-images.githubusercontent.com/40416736/83770435-a3760900-a6b3-11ea-8d42-92147aa6e982.png">


## Checklist:

- [x] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
