### PR TITLE
Datetimepicker showing random language

### DIFF
--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -5,5 +5,6 @@ environment.plugins.append('Provide', new webpack.ProvidePlugin({
   $: 'jquery',
   jQuery: 'jquery',
   Popper: ['popper.js', 'default'],
+  moment: 'moment/moment',
 }));
 module.exports = environment


### PR DESCRIPTION
# Description
- Think previously imported moment package with language japanese, hence the problem of 4 6月 2020.
- Remove the language imported

Notion link: https://www.notion.so/Datetimepicker-error-4-6-2020-2706d067569f42e9bd845d2f21350dce

## Remarks
- Nil

# Testing
- Tested by going through the invoice AP flow and type in <4 6 tab> in the invoice date. It appears as 4 Jun 2020 -> 月 is gone

## Checklist:

- [ ] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
