### PR TITLE
Remove users filtering by company in roles page

### DIFF
--- a/app/views/symphony/roles/index.html.slim
+++ b/app/views/symphony/roles/index.html.slim
@@ -19,10 +19,10 @@
             tr
               td = r.id
               td = r.name.humanize
-              td = r.users.where(company_id: @company.id).count
+              td = r.users.count
               / concatenate first name and last name using pluck, which is more efficient as it works in db level
               / Arel.sql to prevent sql injection through raw SQL
-              td = r.users.where(company_id: @company.id).pluck(Arel.sql("CONCAT_WS(' ', users.first_name, users.last_name)")).join('<br />').html_safe
+              td = r.users.pluck(Arel.sql("CONCAT_WS(' ', users.first_name, users.last_name)")).join('<br />').html_safe
               td style="min-width: 135px;"
                 = link_to "Edit", edit_symphony_role_path(r.id), role: 'button', class: 'btn btn-primary btn-sm mr-1'
                 = link_to "Delete", symphony_role_path(r.id), data: { confirm: 'Are you sure?' }, method: :delete, role: 'button', class: 'btn btn-danger btn-sm'


### PR DESCRIPTION
# Description
- 'Manage Role' page not showing the user who has the role. This is because the users (`role.users`) was filtered by company, so when the user is in another company, it doesn't show up.
- Remove filtering users by company since the role is already filtered in the `roles_controller.rb` index method.

Notion link: https://www.notion.so/Check-on-user-roles-d3c56ea997e84a37bf9389d12253b17d

## Remarks
- Other than that I'm not sure of any other errors. 

# Testing
- Tested with 2 accounts with 2 different roles. Change the company of one that is not superadmin. As the superadmin account, check if the other user's role is still stated in 'Manage Roles' page even if the other user is in another company.

## Checklist:

- [ ] The code follows the conventions of Rails and this project (eg. naming of routes and variables)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code thoroughly
- [x] The code does not break existing functionality
- [ ] I have added instructions and data required to test the code
- [ ] I have tested the changes on the front-end on Chrome, Firefox and IE
