### PR TITLE
Change company gives error page on batches SHOW

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,9 +15,6 @@ class ApplicationController < ActionController::Base
   rescue_from OAuth::Unauthorized, with: :xero_unauthorized
   rescue_from Xeroizer::OAuth::RateLimitExceeded, with: :xero_rate_limit_exceeded
 
-  #Change company in pages that have params in the url. Eg. batches SHOW or workflow SHOW. It will return an error because the changed company doesn't have the particular id to find batch or workflow. Hence this is to rescue from all pages
-  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
-
   after_action :store_location
 
   def store_location
@@ -77,9 +74,5 @@ class ApplicationController < ActionController::Base
     message = 'You have exceeded the number of times you can access Xero in 1 minute. Please wait a few minutes and try again.'
     Rails.logger.error("Xero error: Rate limited exceeded")
     redirect_to symphony_root_path, alert: message
-  end
-
-  def record_not_found
-    redirect_to symphony_root_path
   end
 end

--- a/app/controllers/symphony/users_controller.rb
+++ b/app/controllers/symphony/users_controller.rb
@@ -47,9 +47,9 @@ class Symphony::UsersController < ApplicationController
 
   def change_company
     if @user.update(user_params)
-      redirect_back fallback_location: symphony_root_path, notice: 'Company changed to ' + @user.company.name + '.'
+      redirect_to symphony_root_path, notice: 'Company changed to ' + @user.company.name + '.'
     else
-      redirect_back fallback_location: symphony_root_path, error: 'Sorry, there was an error when trying to switch company.'
+      redirect_to symphony_root_path, error: 'Sorry, there was an error when trying to switch company.'
     end
   end
 


### PR DESCRIPTION
# Description
Change company method uses redirect_back to return to the same url. When user change company on path where it requires a params (eg batches SHOW page with params[:id]), it returns back an error of RecordNotFound as the param is related to the previous company.

Fix:  Redirect to symphony_root_path 

Notion link: https://www.notion.so/{unique-id}

## Remarks
- Figure out how to enhance change company in a future task

# Testing
- Tested by changing company on batches SHOW page, workflow SHOW page, invoice FORM and check if the error is rescued
