### PR TITLE
Modify redirect path when rescued from Xero unauthorized error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,7 +67,7 @@ class ApplicationController < ActionController::Base
   def xero_unauthorized(e)
     message = 'Xero authorization failed - ' + CGI.unescape(e.request.body)
     Rails.logger.error("Xero OAuth error: #{message}")
-    redirect_to edit_company_path, alert: message
+    redirect_to session[:previous_url], alert: message
   end
 
   def xero_rate_limit_exceeded


### PR DESCRIPTION
# Description
User that is not admin/superadmin will face pundit error of 'You are not authorized to edit company!',  because the xero error is rescued and redirected to EDIT company page which the non-admin users got no access to.

Solution: 
Redirect the path from EDIT company path to the previous session url with the xero message printed out.

Notion link: https://www.notion.so/{unique-id}

## Remarks
- NIL

# Testing
- Tested with a shared service account and try to access invoice with a xero account already revoked access (Like test on local but sign in with the same xero acc on production). It will redirect path to previous session with the Xero error message.
