### PR TITLE
Remove textract temporary

### DIFF
--- a/app/controllers/symphony/documents_controller.rb
+++ b/app/controllers/symphony/documents_controller.rb
@@ -46,7 +46,7 @@ class Symphony::DocumentsController < ApplicationController
         # attach and convert method
         attach_and_convert_document(document, params[:response_key])
         # Generate textract ID if the workflow contains the task 'create_invoice payable' or 'create_invoice_receivable'.
-        @generate_textract = GenerateTextract.new(document.id).run_generate if document.workflow&.workflow_actions&.any?{|wfa| wfa.task.task_type == 'create_invoice_payable' or wfa.task.task_type == 'create_invoice_receivable'}
+        # @generate_textract = GenerateTextract.new(document.id).run_generate if document.workflow&.workflow_actions&.any?{|wfa| wfa.task.task_type == 'create_invoice_payable' or wfa.task.task_type == 'create_invoice_receivable'}
         @batch = document&.workflow&.batch
         if params[:document_type] == 'batch-uploads'
           first_task = @batch.template&.sections.first.tasks.first

--- a/app/views/symphony/invoices/new.html.slim
+++ b/app/views/symphony/invoices/new.html.slim
@@ -25,10 +25,10 @@
               br
               = @document.filename
           // button to run textract
-          button class="btn btn-primary do-textract" Extract Invoice Data
-          = hidden_field_tag :template, @workflow.template.slug, class:"template-field"
-          = hidden_field_tag :workflow_id, @workflow.id, class:"workflow-field"
-          = hidden_field_tag :textract_job_id, @document.aws_textract_job_id, class:"textract-job-id-field"
+          / button class="btn btn-primary do-textract" Extract Invoice Data
+          / = hidden_field_tag :template, @workflow.template.slug, class:"template-field"
+          / = hidden_field_tag :workflow_id, @workflow.id, class:"workflow-field"
+          / = hidden_field_tag :textract_job_id, @document.aws_textract_job_id, class:"textract-job-id-field"
         .col-auto.ml-auto.text-center
           | Invoice
           .invoice-nav


### PR DESCRIPTION
# Description
- Comment out textract related stuff to prevent aws textract from charging while testing
- Remove 'Extract Invoice Data' button

Notion link: https://www.notion.so/{unique-id}

## Remarks
- Bring back next time. Just uncomment

# Testing
- Tested by creating a batch upload AP flow and check if textract_id is generated for the document
- Checked that "Generate Textract" button is removed