### PR TITLE
Add more allowed file types

### DIFF
--- a/app/webpacker/src/javascripts/dashboard/components/uppy.js
+++ b/app/webpacker/src/javascripts/dashboard/components/uppy.js
@@ -85,7 +85,7 @@ function setupUppy(element){
       maxNumberOfFiles: 50,
       minNumberOfFiles: null,
       // Only allow images or PDF
-      allowedFileTypes: ['image/*', '.pdf', '.doc', '.docs', '.xls', '.xlsx', '.ppt', '.pptx']
+      allowedFileTypes: ['image/*', '.pdf', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', 'text/csv']
     },
     // Create batch on upload, only when .batchUploads element exists (which is dashboard drag and drop)
     onBeforeUpload: (files) => {


### PR DESCRIPTION
# Description
- Add more allowed file types for Uppy uploading
- Added file types are: '.doc', '.docs', '.xls', '.xlsx', '.ppt', '.pptx'

Notion link: https://www.notion.so/{unique-id}

## Remarks
- Nil

# Testing
- Checked that certain allowed file types are able to upload
- Checked: .doc, .xlsx, .pptx
