### PR TITLE
Img-responsive to img-fluid

### DIFF
--- a/app/views/symphony/documents/multiple_edit.html.slim
+++ b/app/views/symphony/documents/multiple_edit.html.slim
@@ -20,7 +20,7 @@
                       - url_array << image
                     - url_array.each do |url|
                       - display_url = url_for(url)
-                      img src='#{display_url}' class='img-responsive figure-img img-fluid' style="width:500px;"
+                      img src='#{display_url}' class='figure-img img-fluid' style="width:500px;"
                     figcaption.figure-caption.text-center = document.raw_file.blob.filename
                   - else
                     // IF document dont have filename, it is assumed that conversion has yet to be done
@@ -29,7 +29,7 @@
                     - elsif File.extname(document.file_url) == '.pdf'
                       iframe src="https://docs.google.com/viewer?url=https:#{document.file_url}&embedded=true" width="100%" height="500" style="border: none;"
                     - else
-                      = image_tag(document[:file_url], class: 'img-responsive figure-img img-fluid', style: 'width:500px')
+                      = image_tag(document[:file_url], class: 'figure-img img-fluid', style: 'width:500px')
                     figcaption.figure-caption.text-center = document.filename
               td
                 = form_for(document, url: symphony_document_path(document.id, format: 'json'), remote: true) do |f|

--- a/app/views/symphony/documents/show.html.slim
+++ b/app/views/symphony/documents/show.html.slim
@@ -9,9 +9,9 @@
         - url_array << image
       - url_array.each do |url|
         - display_url = url_for(url)
-        img src='#{display_url}' class='img-responsive figure-img img-fluid' style="width:500px;"
+        img src='#{display_url}' class='figure-img img-fluid' style="width:500px;"
     - elsif @document.file_url.present? and ['.jpg', '.jpeg', '.png', '.gif'].include? File.extname(@document.file_url)
-      = image_tag(@document.file_url, class: 'img-responsive')
+      = image_tag(@document.file_url, class: 'img-fluid')
     - else
       iframe src="https://docs.google.com/viewer?url=https:#{@document.file_url}&embedded=true" width="100%" height="1000" style="border: none;"
   .col-md-4.col-sm-12

--- a/app/views/symphony/invoices/_document.html.slim
+++ b/app/views/symphony/invoices/_document.html.slim
@@ -14,7 +14,7 @@
         div.carousel-inner
           - @document.converted_images.each.with_index(0) do |image, index|
             div. class=["carousel-item", index.zero? ? 'active' : '' ]
-              = link_to image_tag(image, class: 'img-responsive zoomed-image')
+              = link_to image_tag(image, class: 'zoomed-image')
           end
         - if @document.converted_images.count > 1
           a.carousel-control-prev data-slide="prev" href="#carouselExampleIndicators" role="button"
@@ -25,10 +25,10 @@
             span.sr-only Next
   - elsif @document.raw_file.attached?
     .img-magnifier-container
-      = link_to image_tag(@document.raw_file, class: 'img-responsive zoomed-image'), @document.raw_file , {target: "_blank"}
+      = link_to image_tag(@document.raw_file, class: 'zoomed-image'), @document.raw_file , {target: "_blank"}
   - else
     .img-magnifier-container
-      = link_to image_tag(@document.file_url, class: 'img-responsive zoomed-image'), @document.file_url , {target: "_blank"}
+      = link_to image_tag(@document.file_url, class: 'zoomed-image'), @document.file_url , {target: "_blank"}
   span.form-group.float-right.mt-4
     div.kt-switch.mt-1
       label.form-inline

--- a/app/views/symphony/workflows/data_entry.html.slim
+++ b/app/views/symphony/workflows/data_entry.html.slim
@@ -7,7 +7,7 @@
       | No documents available. Please upload documents first.
     - else
       - if ['.jpg', '.jpeg', '.png', '.gif'].include? File.extname(@document.file_url)
-        = image_tag(@document.file_url, class: 'img-responsive')
+        = image_tag(@document.file_url, class: 'img-fluid')
       - else
         iframe src="https://docs.google.com/viewer?url=https:#{@document.file_url}&embedded=true" width="100%" height="1000" style="border: none;"
   .col-md-6

--- a/public/404.html
+++ b/public/404.html
@@ -125,7 +125,7 @@
       <div class="cover-container">
         <div class="inner cover">
           <a href="/">
-            <img src="assets/excide-logo-light-ee31ec8c78e4ad2b5b69fb582dd2daf3dded8a254767ae241b68ba5ac8375382.png" style="padding: 50px 100px 0;" class="img-responsive" title="Excide Logo" alt="Excide">
+            <img src="assets/excide-logo-light-ee31ec8c78e4ad2b5b69fb582dd2daf3dded8a254767ae241b68ba5ac8375382.png" style="padding: 50px 100px 0;" class="img-fluid" title="Excide Logo" alt="Excide">
           </a>
           <h1>404 Page Not Found.</h1>
           <p class="lead">The page you were looking for doesn't exist. You may have mistyped the address or the page may have moved.</p>

--- a/public/422.html
+++ b/public/422.html
@@ -125,7 +125,7 @@
       <div class="cover-container">
         <div class="inner cover">
           <a href="/">
-            <img src="assets/excide-logo-light-ee31ec8c78e4ad2b5b69fb582dd2daf3dded8a254767ae241b68ba5ac8375382.png" style="padding: 50px 100px 0;" class="img-responsive" title="Excide Logo" alt="Excide">
+            <img src="assets/excide-logo-light-ee31ec8c78e4ad2b5b69fb582dd2daf3dded8a254767ae241b68ba5ac8375382.png" style="padding: 50px 100px 0;" class="img-fluid" title="Excide Logo" alt="Excide">
           </a>
           <h1>The change you wanted was rejected.</h1>
           <p class="lead">Maybe you tried to change something you didn't have access to.</p>

--- a/public/500.html
+++ b/public/500.html
@@ -125,7 +125,7 @@
       <div class="cover-container">
         <div class="inner cover">
           <a href="/">
-            <img src="assets/excide-logo-light-ee31ec8c78e4ad2b5b69fb582dd2daf3dded8a254767ae241b68ba5ac8375382.png" style="padding: 50px 100px 0;" class="img-responsive" title="Excide Logo" alt="Excide">
+            <img src="assets/excide-logo-light-ee31ec8c78e4ad2b5b69fb582dd2daf3dded8a254767ae241b68ba5ac8375382.png" style="padding: 50px 100px 0;" class="img-fluid" title="Excide Logo" alt="Excide">
           </a>
           <h1>We're sorry, but something went wrong.</h1>
           <p class="lead">There was an error in the application. If the problem persists, please contact us via the chat function in the application.</p>


### PR DESCRIPTION
# Description

Previously, document image overflows and is ugly.
Rename all instances of img-responsive to img-fluid as Bootstrap 4 renamed them.
https://blog.getbootstrap.com/2015/12/08/bootstrap-4-alpha-2/

Notion link: https://www.notion.so/Document-view-photo-size-fills-up-the-whole-page-61dd916b5cc5422486c4dc9c3dbdd1f2

## Remarks

Conditions to display raw_file are not properly implemented in most pages except invoices.

# Testing

checked that img looks okay in different screen size for pdf and non pdf.
have yet checked data_entry cause i got an error when trying to enter the page.

