### PR TITLE
paginate batch workflows in groups of 10

### DIFF
--- a/app/controllers/symphony/batches_controller.rb
+++ b/app/controllers/symphony/batches_controller.rb
@@ -48,6 +48,8 @@ class Symphony::BatchesController < ApplicationController
     # Come from batch uploads (create method). [number, 0].max() is to prevent negative number from being passed in
     @processing_files = [(params[:files_count].to_i - @batch.workflows.count), 0].max() if params[:files_count].present?
     @completed = @batch.workflows.where(completed: true).length
+    
+    @per_batch = Kaminari.paginate_array(@batch.workflows.includes(:documents, :invoice, :template, :company).order(created_at: :asc)).page(params[:page]).per(10)
   end
 
   def destroy

--- a/app/views/symphony/batches/show.html.slim
+++ b/app/views/symphony/batches/show.html.slim
@@ -36,7 +36,7 @@
                         .header-info
                           ' #{task.role.name.humanize}
                 tbody
-                  - @batch.workflows.includes(:documents, :invoice, :template, :company).order(created_at: :asc).each do |wf|
+                  - @per_batch.each do |wf|
                     tr
                       / Only show the processing buttons and line when workflow_actions are created
                       - if wf.documents.empty? and wf.workflow_actions.present?
@@ -74,3 +74,4 @@
                       - section.tasks.includes(:role).order(position: :asc).each do |task|
                         td class="text-center #{'important-task' if task.important}"
                           = render "symphony/batches/tasks/#{task.task_type}", workflow: wf, action: task.get_workflow_action(wf.company, wf.id) if task.get_workflow_action(wf.company, wf.id).present?
+              = paginate @per_batch, views_prefix: 'dashboard'


### PR DESCRIPTION
# Description

Paginated workflows in each batch ID in sets of 10.

Notion link: https://www.notion.so/Paginate-workflows-in-batch-show-page-ec232814e8174b3e8fee70c558da10c2

## Remarks

Saw the reject invoice icon having position that is off (.rejected-invoice-circle) but haven't changed anything (possible future bug fix)

# Testing

Tried with staging data and cross reference with other paginated pages to make sure everything is correct
