### PR TITLE
Enhance/calculate due date when user type special rule

### DIFF
--- a/app/views/symphony/invoices/_form.html.slim
+++ b/app/views/symphony/invoices/_form.html.slim
@@ -26,13 +26,17 @@
         .form-row
           .form-group.col-md-2
             = f.label :invoice_date, 'Invoice Date'
+            a.pop.ml-2 data-container="body" title='Eg. Enter "3 6 tab" to get 3 June 2020' data-html="true" data-placement="top" data-toggle="kt-tooltip" data-trigger="hover"
+              i.fa.fa-info-circle
             #datetimepicker.input-group.date.dateinvoice data-target-input="nearest"
               = f.text_field :invoice_date, class: 'form-control autodate invoicedate dateinvoice', value:"#{@invoice.invoice_date.present? ? @invoice.invoice_date.strftime('%d %b %Y') : ''}", id: 'datetimepicker1', 'data-target': '#datetimepicker1'
               .input-group-append data-target="#datetimepicker" data-toggle="datetimepicker"
                 .input-group-text
                   i.fa.fa-calendar
           .form-group.col-md-2
-            = f.label :due_date, 'Due Date'
+            = f.label :due_date, 'Due Date '
+            a.pop.ml-2 data-container="body" title='Type "+30" to add 30 days from invoice date to due date' data-html="true" data-placement="top" data-toggle="kt-tooltip" data-trigger="hover"
+              i.fa.fa-info-circle
             #datetimepicker2.input-group.date.dateinvoice data-target-input="nearest"
               = f.text_field :due_date, class: 'form-control autodate duedate dateinvoice', value:"#{@invoice.due_date.present? ? @invoice.due_date.strftime('%d %b %Y') : ''}", id: 'datetimepicker3', 'data-target': '#datetimepicker3'
               .input-group-append data-target="#datetimepicker2" data-toggle="datetimepicker"

--- a/app/webpacker/src/javascripts/dashboard/components/date_time_picker.js
+++ b/app/webpacker/src/javascripts/dashboard/components/date_time_picker.js
@@ -55,9 +55,6 @@ $(document).on("turbolinks:load", function() {
           let d = moment(dueDate).format("D MMM YYYY");
           $(".duedate").val(d);
         }
-        else{
-          $(".duedate").val("Invalid Date");
-        }
       }
       else{
         // do change the field value with date format


### PR DESCRIPTION
# Description
When user type '+30' and press tab into due date field in invoice, it will take the invoice date and add 30 days.
The condition is that invoice date must be present for that to work

Notion link: https://www.notion.so/Calculate-the-due-date-from-the-invoice-date-when-user-adds-in-number-of-days-ce97394843fd4111a21a5b57e53897f0

## Remarks
- Nil

# Testing
- Tested by typing +30 and checked that due date is invoice date + 30 days
- Tested to check if the old tab still works, like 2 7 tab