### PR TITLE
add flatten: true when converting

### DIFF
--- a/app/services/conversion_service.rb
+++ b/app/services/conversion_service.rb
@@ -22,7 +22,7 @@ class ConversionService
       url = @document.raw_file.service_url
       page_count = MiniMagick::Image.open(url).pages.count
       page_count.times do |page_number|
-        result = ImageProcessing::MiniMagick.source(url).loader(page: page_number, density: 100).convert("png").call
+        result = ImageProcessing::MiniMagick.source(url).loader(page: page_number, density: 100, flatten:true).convert("png").call
         @document.converted_images.attach(io: result, filename: result.path.split('/').last, content_type: "image/png")
       end
     end


### PR DESCRIPTION
# Description
previously, electronic pdf has transparency problem when using magnifier
add flatten: true to fix it

Notion link: https://www.notion.so/Electronic-PDF-invoices-that-are-converted-to-image-have-transparent-background-so-magnifier-won-t-w-e10dba82603a474c8c53f16fe8bd169b

## Remarks

# Testing

tested with the following documents
[200701_Lifeline_-363.80.pdf](https://github.com/hschin/excide/files/4951574/200701_Lifeline_-363.80.pdf)
[Uploading 190214_Sunseap_-577.16.pdf…]()
[unclear-image.pdf](https://github.com/hschin/excide/files/4951577/unclear-image.pdf)


