### PR TITLE
Change zendesk widget source for paloe

### DIFF
--- a/app/views/layouts/metronic/application.html.slim
+++ b/app/views/layouts/metronic/application.html.slim
@@ -63,9 +63,9 @@ html lang="en"
       i.fa.fa-arrow-up
     /! end::Scrolltop
 
-    <!-- Start of excide Zendesk Widget script -->
-    script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=d91fc85f-b1cf-4d65-b9f8-0c90f5132187"
-    <!-- End of excide Zendesk Widget script -->
+    / <!-- Start of paloe Zendesk Widget script -->
+    <script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=9e256da6-64dd-4eb7-b18c-cdf3dd65fd66"> </script>
+    / <!-- End of paloe Zendesk Widget script -->
 
     /! begin::Global Config(global config for global JS sciprts)
     javascript:


### PR DESCRIPTION
# Description
- Zendesk support widget not appearing due to different src as zendesk was changed from excide to paloe
- Put new script tag from zendesk paloe

Notion link: https://www.notion.so/Zendesk-not-appearing-in-production-site-c49382974606402b8e7ccc323322e4b7

## Remarks
- Nil

# Testing
- Checked on localhost and test sending a support ticket