### PR TITLE
fix routine page show cycles

### DIFF
--- a/app/controllers/symphony/workflows_controller.rb
+++ b/app/controllers/symphony/workflows_controller.rb
@@ -51,7 +51,7 @@ class Symphony::WorkflowsController < ApplicationController
     @sections = @template.sections
     @get_activities = PublicActivity::Activity.includes(:owner).where(recipient_type: "Workflow", recipient_id: @workflow.id).order("created_at desc")
     @activities = Kaminari.paginate_array(@get_activities).page(params[:page]).per(5)
-    @workflows = @template.workflows.select{|wf| params[:year].present? ? wf.created_at.year.to_s == params[:year] : wf.created_at.year == 2020}.sort_by{|wf| wf.created_at}
+    @workflows = @template.workflows.select{|wf| params[:year].present? ? wf.created_at.year.to_s == params[:year] : wf.created_at.year == @workflow.created_at.year}.sort_by{|wf| wf.created_at}
 
     if @workflow.completed?
       @section = params[:section_id] ? @sections.find(params[:section_id]) : @sections.last

--- a/app/views/symphony/workflows/show.html.slim
+++ b/app/views/symphony/workflows/show.html.slim
@@ -5,7 +5,7 @@
       .label.label-inline.label-dark.ml-4
         span On-demand
   .col-md-6.d-flex.justify-content-end
-    = select_tag('year', options_for_select(["2020", "2019", "2018"], selected: params[:year], include_blank: "2020"), class: 'selectize selectize-year mr-2')
+    = select_tag('year', options_for_select(["2020", "2019", "2018"], selected: params[:year].present? ? params[:year] : @workflow.created_at.year.to_s), class: 'selectize selectize-year mr-2')
     - if policy(@template).edit? || policy(@template).destroy?
       .dropdown.dropdown-inline.float-right
         a.btn.btn-icon.btn-link href="#" aria-expanded="false" aria-haspopup="true" data-toggle="dropdown"


### PR DESCRIPTION
# Description

Previously when user goes to workflows show page (via home index or workflows index) wfa are shown at the right side but list of workflows does not appear. This is cause the workflow created_at year is not 2020 and by default the controller filters to 2020.
Change filter condition to filter by current workflow's year if params[:year] is empty. (dropdown to sort by year is not used)

Notion link: https://www.notion.so/Routine-page-doesn-t-show-all-the-cycles-correctly-8e468783d98c4281998cce9f004b2d57

## Remarks

# Testing

Tested with workflow created at 2019.
<img width="1435" alt="Screenshot 2020-07-28 at 1 44 49 AM" src="https://user-images.githubusercontent.com/47408304/88573911-0fea0480-d074-11ea-8194-c10625d5c82e.png">

