### PR TITLE
fix cannot create new cycle

### DIFF
--- a/app/views/symphony/workflows/index.html.slim
+++ b/app/views/symphony/workflows/index.html.slim
@@ -15,7 +15,7 @@
           .dropdown-item = link_to "Delete", symphony_template_path(template_slug: @template.slug), data: { confirm: 'This will delete all related workflows and batches as well. Are you sure?' , remote: true}, method: :delete if policy(@template).destroy?
 .row
   .col-md-5
-    table.table.table-hover
+    table.table.table-hover.mb-0
       thead.thead-light
         tr
           th colspan="4" To complete
@@ -41,6 +41,9 @@
                   i.fa.fa-xs.fa-circle.text-primary.mr-3
             td width="25%"
               = wf.deadline&.strftime("%d %b %Y")
+    .btn.btn-block.btn-hover-light-secondary.text-center
+      i.material-icons.text-muted add
+      = link_to "Add new cycle", new_symphony_workflow_path(@template.slug), class: "text-muted"
   .col-md-7
     table.table.table-borderless
       thead.thead-light

--- a/app/views/symphony/workflows/show.html.slim
+++ b/app/views/symphony/workflows/show.html.slim
@@ -15,7 +15,7 @@
           .dropdown-item = link_to "Delete", symphony_template_path(template_slug: @template.slug), data: { confirm: 'This will delete all related workflows and batches as well. Are you sure?' , remote: true}, method: :delete if policy(@template).destroy?
 .row
   .col-md-5
-    table.table.table-hover
+    table.table.table-hover.mb-0
       thead.thead-light
         tr
           th colspan="4" To complete
@@ -41,6 +41,9 @@
                   i.fa.fa-xs.fa-circle.text-primary.mr-3
             td width="25%"
               = wf.deadline&.strftime("%d %b %Y")
+    .btn.btn-block.btn-hover-light-secondary.text-center
+      i.material-icons.text-muted add
+      = link_to "Add new cycle", new_symphony_workflow_path(@template.slug), class: "text-muted"
   .col-md-7
     table.table.table-borderless.table-hover
       thead.thead-light


### PR DESCRIPTION
# Description

Previously there is no way to create a new workflow other than through the url.
Add button below table to create new workflow (cycle).

Normal:
<img width="1440" alt="Screenshot 2020-07-28 at 4 42 01 AM" src="https://user-images.githubusercontent.com/47408304/88590221-eab5c000-d08c-11ea-8a98-854c346d8f46.png">

Hover:
<img width="1439" alt="Screenshot 2020-07-28 at 4 42 08 AM" src="https://user-images.githubusercontent.com/47408304/88590205-e689a280-d08c-11ea-892f-4f9fa710e278.png">

Notion link: https://www.notion.so/Cannot-create-new-cycle-for-routine-2dff02d9b25949e188958721aafa0e8c

## Remarks

Not following the design yet.

# Testing

Button links to create workflow