### PR TITLE
Change zendesk widget script tag

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -85,6 +85,6 @@ html lang="en"
       i.fa.fa-arrow-up
     /! end::Scrolltop
 
-    <!-- Start of paloe Zendesk Widget script -->
-    <script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=9e256da6-64dd-4eb7-b18c-cdf3dd65fd66"> </script>
-    <!-- End of paloe Zendesk Widget script -->
+    /! Start of paloe Zendesk Widget script
+    script#ze-snippet src="https://static.zdassets.com/ekr/snippet.js?key=9e256da6-64dd-4eb7-b18c-cdf3dd65fd66" 
+    /! End of paloe Zendesk Widget script


### PR DESCRIPTION
# Description

Zendesk Widget disappeared again. Add the widget script tag

Notion link: https://www.notion.so/{unique-id}

## Remarks
- Nil

# Testing
- Checked on development
