### PR TITLE
"Add new cycle" links to create workflow

### DIFF
--- a/app/views/symphony/workflows/index.html.slim
+++ b/app/views/symphony/workflows/index.html.slim
@@ -43,7 +43,7 @@
               = wf.deadline&.strftime("%d %b %Y")
     .btn.btn-block.btn-hover-light-secondary.text-center
       i.material-icons.text-muted add
-      = link_to "Add new cycle", new_symphony_workflow_path(@template.slug), class: "text-muted"
+      = link_to "Add new cycle", symphony_workflows_path(@template.slug), method: :post, class: "text-muted"
   .col-md-7
     table.table.table-borderless
       thead.thead-light

--- a/app/views/symphony/workflows/show.html.slim
+++ b/app/views/symphony/workflows/show.html.slim
@@ -43,7 +43,7 @@
               = wf.deadline&.strftime("%d %b %Y")
     .btn.btn-block.btn-hover-light-secondary.text-center
       i.material-icons.text-muted add
-      = link_to "Add new cycle", new_symphony_workflow_path(@template.slug), class: "text-muted"
+      = link_to "Add new cycle", symphony_workflows_path(@template.slug), method: :post, class: "text-muted"
   .col-md-7
     table.table.table-borderless.table-hover
       thead.thead-light


### PR DESCRIPTION
# Description

Previously "Add new cycle" links to new workflow but it is misleading as data on the new workflow page is not needed and not saved.
Upon clicking add new cycle workflow is created directly.

Notion link: https://www.notion.so/{unique-id}

## Remarks

Need to remove workflow new views?

# Testing

Click on "add new cycle" on both workflows show and index page creates workflow and redirects to workflow show page
