### PR TITLE
Removed blue highlight from .dropdown-item and set it to same colour …

### DIFF
--- a/app/webpacker/src/stylesheets/metronic/css/custom.scss
+++ b/app/webpacker/src/stylesheets/metronic/css/custom.scss
@@ -20,7 +20,8 @@ h1, h2, h3, h4, h5, h6 {
 
 //remove on click highlight of dropdown-item
 .dropdown-item.active, .dropdown-item:active {
-  background-color: #F3F6F9 !important; }
+  background-color: #F3F6F9 !important; 
+}
 
 // Class to make five column in one row
 .col-2dot4,


### PR DESCRIPTION
…as the hover highlight

# Description

![image](https://user-images.githubusercontent.com/38323239/89270246-a9fe0e00-d66d-11ea-9cf9-deb723de0f17.png)
Dropdown item in routines used to have blue highlight on click, set the colour to be the same as the hover colour such that there is no colour change on click. This was done by overwriting the bootstrap css default component colour in the custom.scss file.

![image](https://user-images.githubusercontent.com/38323239/89270327-c7cb7300-d66d-11ea-9a98-d3562606baa9.png)
This change is also reflected in the above dropdown menu on the symphony homepage.


Notion link: https://www.notion.so/96a0f98d494f4459b6c6b07e278cf1c7?v=44abc2db86e64c7abcc97c007bc7bd6d&p=c37d96649c22443fb7b574b884497bc1

## Remarks

N.A.

# Testing

For an account with existing routines, visit
- http://localhost:3000/symphony
- or click on the link to the routine from the homepage

and referring to the 2 above images in the PR description, click on the 3 dots dropdown menu icon, then click and hold on one of the dropdown items to verify that the colour does not change and is no longer blue.
