### PR TITLE
Routine details design fixes

### DIFF
--- a/app/views/symphony/workflows/_task.html.slim
+++ b/app/views/symphony/workflows/_task.html.slim
@@ -11,7 +11,7 @@
                     i.material-icons-outlined.font-size-h6 check
                     | Completed
               - else
-                .btn.btn-sm.btn-outline-secondary style=((action.task != task && template.ordered?) ? "pointer-events: none" : "")
+                .btn.btn-sm.btn-outline-secondary class=((action.task != task && template.ordered?) ? "disabled" : "")
                   .d-flex.align-items-center
                     i.material-icons-outlined.font-size-h6 check
                     = link_to "Mark as Complete", task_toggle_symphony_workflow_path(workflow_name: action.workflow.template.slug, workflow_id: action.workflow.id, task_id: action.task.id), data: {remote: true, method: "POST"}, class: "text-dark"

--- a/app/webpacker/src/stylesheets/metronic/css/custom.scss
+++ b/app/webpacker/src/stylesheets/metronic/css/custom.scss
@@ -128,6 +128,10 @@ td.day.has-events.fc-day-top.fc-past {
 .material-icons-outlined {
   color: #515163;
 }
+
+.disabled {
+  pointer-events: none;
+}
 @import "~bootstrap/scss/functions";
 @import "~bootstrap/scss/variables";
 $theme-colors: (


### PR DESCRIPTION
# Description

Previously, Mark as Complete button was misleading as it looks the same whether it is clickable or not.
Show invoice if present on create invoice payable, coding invoice and xero send invoice tasks.
Add custom class disabled to mark as complete.

Notion link: https://www.notion.so/Mark-as-completed-button-is-disabled-but-looks-the-same-as-the-one-that-is-not-disabled-6952adc4f92f4e13a25a81bbd5bb9884
https://www.notion.so/Show-invoice-attachment-in-the-relevant-step-21e86c8e1058462c8d20ec3d7c7d2984

## Remarks

Buttons that are disabled will now be unclickable.
Future enhancements:
The tasks buttons will still need to add class disabled based on whether task is current task and user assigned is current user if the template is ordered.

# Testing

Clicking the invoice brings you to invoice show page.
Mark as Complete looks disabled
