### PR TITLE
Display filename

### DIFF
--- a/app/views/symphony/workflows/_task.html.slim
+++ b/app/views/symphony/workflows/_task.html.slim
@@ -75,7 +75,7 @@
                   .d-flex
                     = link_to symphony_document_path(d), data: { confirm: 'Are you sure?' }, method: :delete, remote: true do
                       i.material-icons.font-size-h6.text-dark.mr-3 cancel
-                    = link_to d.filename, symphony_document_path(d)
+                    = link_to (d.raw_file.attached? ? d.raw_file.filename : d.filename), symphony_document_path(d)
                     br
           - if workflow.invoice.present? && (["create_invoice_payable", "xero_send_invoice", "coding_invoice"].include? action.task.task_type)
             .row.mb-4


### PR DESCRIPTION
# Description

Previously, documents filename is displayed as /symphony/documents/<RANDOM UUID> in _task.
Temporary fix by calling raw_file.filename.

Notion link: https://www.notion.so/{unique-id}

## Remarks

Better solution is to save document.filename = document.raw_file.filename when document is created and add a rake task to save existing documents without filename

# Testing

filename is displayed