### PR TITLE
fix confirmation (rollbar webpacker error)

### DIFF
--- a/app/views/devise/confirmations/new.html.slim
+++ b/app/views/devise/confirmations/new.html.slim
@@ -1,18 +1,15 @@
-section.height-100.imagebg data-overlay="4"
-  .background-image-holder
-    = image_pack_tag 'media/src/images/hero-image.jpg', alt: "background"
-  .container.pos-vertical-center
-    .row.d-flex.justify-content-center
-      .col-md-7.col-lg-5
-        .boxed.boxed--lg.boxed--border
-          h2.text-center Resend confirmation instructions
+.d-flex.align-items-center.container.h-100
+  .row.w-100
+    .col-sm-6.mt-5
+      .row.d-flex.justify-content-center
+        .col-sm-9
+          h1.header-bold.mb-5.text-center Resend confirmation instructions
           = form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
-            .row
-              .col-md-12
-                = devise_error_messages!
-                .field = f.email_field :email, autofocus: true, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), placeholder: "Email"
-
-              .col-md-12
-                = f.submit "Resend confirmation instructions", class:"btn btn--excide type--uppercase"
-
-          = render "devise/shared/links"
+            = devise_error_messages!
+            .form-group
+              = f.email_field :email, autofocus: true, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), placeholder: "Email", class: 'form-control'
+            = hidden_field_tag :confirmation_token,@confirmation_token
+            .form-group
+              = f.submit "Resend confirmation instructions", class: "btn btn-primary col-sm-12"
+    .col-sm-6
+      = image_pack_tag 'media/src/images/symphony/login.png', alt: "login-page", class: 'img-fluid float-right'

--- a/app/views/devise/confirmations/show.html.slim
+++ b/app/views/devise/confirmations/show.html.slim
@@ -1,22 +1,18 @@
-section.height-100.imagebg.text-center data-overlay="4"
-  .background-image-holder
-    = image_pack_tag 'media/src/images/hero-image.jpg', alt: "background"
-  .container.pos-vertical-center
-    .row
-      .col-md-7.col-lg-5
-        .boxed.boxed--lg.boxed--border
-          h2 Account Event
+.d-flex.align-items-center.container.h-100
+  .row.w-100
+    .col-sm-6.mt-5
+      .row.d-flex.justify-content-center
+        .col-sm-9
+          h1.header-bold.mb-5.text-center Activate Account
           = form_for resource, :as => resource_name, :url => update_user_confirmation_path, :html => {:method => 'put'}, :id => 'event-form' do |f|
-            .row
-              .col-md-12
-                = devise_error_messages!
-                ' Account Event
-                - if resource.first_name
-                  | for #{resource.email}
-              - if @requires_password
-                .col-md-12
-                  = f.password_field :password, placeholder: "Choose a Password"
-                  = f.password_field :password_confirmation, placeholder: "Password Confirmation"
-              .col-md-12
-                = hidden_field_tag :confirmation_token,@confirmation_token
-                p= f.submit "Activate", class:"btn btn--excide type--uppercase"
+            = devise_error_messages!
+            - if @requires_password
+              .form-group
+                = f.password_field :password, placeholder: "Choose a Password", class: 'form-control'
+              .form-group
+                = f.password_field :password_confirmation, placeholder: "Password Confirmation", class: 'form-control'
+            = hidden_field_tag :confirmation_token,@confirmation_token
+            .form-group
+              = f.submit "Activate", class: "btn btn-primary col-sm-12"
+    .col-sm-6
+      = image_pack_tag 'media/src/images/symphony/login.png', alt: "login-page", class: 'img-fluid float-right'


### PR DESCRIPTION
# Description

remove hero-image(caused rollbar error)
change design to follow the sign in page.

<img width="1440" alt="Screenshot 2020-08-18 at 6 39 41 AM" src="https://user-images.githubusercontent.com/47408304/90451298-17a24380-e11e-11ea-88b6-27b848528ae0.png">
<img width="1440" alt="Screenshot 2020-08-18 at 6 39 31 AM" src="https://user-images.githubusercontent.com/47408304/90451311-1cff8e00-e11e-11ea-8963-aef39b174e6e.png">


Notion link: https://www.notion.so/Rollbar-webpacker-6e52d91a1f0f42ca93c824160257d110

## Remarks

# Testing

Able to confirm account and resend confirmation email