### PR TITLE
Fix delete documents error

### DIFF
--- a/app/controllers/symphony/documents_controller.rb
+++ b/app/controllers/symphony/documents_controller.rb
@@ -117,13 +117,12 @@ class Symphony::DocumentsController < ApplicationController
 
   def destroy
     authorize @document
-
     if @document.destroy
-      redirect_back fallback_location: symphony_documents_path
       respond_to do |format|
-        format.html { redirect_to symphony_document_path, notice: 'Document was successfully deleted.' }
-        format.js  { flash[:notice] = 'Document was successfully deleted.' }
+        format.html { redirect_to symphony_documents_path }
+        format.js   { render js: 'Turbolinks.visit(location.toString());' }
       end
+      flash[:notice] = 'Document was successfully deleted.'
     end
   end
 


### PR DESCRIPTION
# Description

https://rollbar.com/excide/excide/items/496/?utm_campaign=new_item_message&utm_medium=slack&utm_source=rollbar-notification
Previously, there were multiple redirects causing the rollbar error and a typo in redirect path.
Change the code according to templates controller destroy method.

Notion link: https://www.notion.so/{unique-id}

## Remarks

# Testing
Delete existing documents from documents index and show page and workflow partial.
Create new documents and delete them.
Create new batches and workflows, upload files and delete them.