### PR TITLE
Fix change routine error

### DIFF
--- a/app/controllers/symphony/workflows_controller.rb
+++ b/app/controllers/symphony/workflows_controller.rb
@@ -327,9 +327,9 @@ class Symphony::WorkflowsController < ApplicationController
   private
 
   def set_template
-    @template = policy_scope(Template).where(title: params[:workflow_name])
+    @template = policy_scope(Template).find_by(title: params[:workflow_name])
     #this is for clicking notifications of other companies
-    if @template.empty?
+    if @template.nil?
       #if scope fails, find template without scope and change user's company if user has role in that company
       @template = Template.find(params[:workflow_name])
       if @user.roles.where(resource_id: @template.company_id, resource_type: "Company").present?


### PR DESCRIPTION
# Description

<img width="1440" alt="Screenshot 2020-08-25 at 6 21 32 PM" src="https://user-images.githubusercontent.com/47408304/91163234-d4d50280-e6ff-11ea-87c8-05e069b6d1d4.png">

Error when trying to change routine via sidebar due to policy_scope(Template).where(title: params[:workflow_name]) being an array rather than an object
Fix by changing the set_template method in workflows controller to use find_by.

Notion link: https://www.notion.so/Fix-change-template-bug-b85b5c9d3260401ab3f4c2698cd8e144

## Remarks

# Testing

Change routine via sidebar.
As I wrote the code causing the error for https://github.com/paloesg/excide/pull/699/files, test that clicking notifications from another company changes current_user's company (does not break!).