### PR TITLE
Minor fixes for timesheet

### DIFF
--- a/app/controllers/conductor/events_controller.rb
+++ b/app/controllers/conductor/events_controller.rb
@@ -142,7 +142,7 @@ class Conductor::EventsController < ApplicationController
   def set_company_and_clients
     @user = current_user
     @company = @user.company
-    @clients = Client.where(company_id: @company.id)
+    @clients = Client.where(company_id: @company.id).sort_by(&:name)
   end
 
   def set_staffers
@@ -151,9 +151,9 @@ class Conductor::EventsController < ApplicationController
 
   def get_users_and_service_lines
     # To be tagged using acts_as_taggable_on gem
-    @service_lines = ['NA', 'Virtual Financial Analysis', 'Financial Function Outsourcing', 'Fundraising Advisory', 'Exit Planning', 'Digital Implementation', 'Digital Strategy']
+    @service_lines = ['NA', 'Virtual Financial Analysis', 'Financial Function Outsourcing', 'Fundraising Advisory', 'Exit Planning', 'Digital Implementation', 'Digital Strategy'].sort
     # Get users who have roles consultant, associate and staffer so that staffer can allocate these users
-    @users = User.joins(:roles).where({roles: {name: ["consultant", "associate", "staffer"], resource_id: @company.id}}).uniq
+    @users = User.joins(:roles).where({roles: {name: ["consultant", "associate", "staffer"], resource_id: @company.id}}).uniq.sort_by(&:first_name)
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/views/conductor/events/index.html.slim
+++ b/app/views/conductor/events/index.html.slim
@@ -38,9 +38,9 @@ hr
         .form-group.mr-3
           = f.date_field :start_time, class: 'form-control', required: true
         .form-group.mr-3
-          = f.select :client_id, @clients.map { |client| [client.name, client.id] }.sort, {selected: @event.client_id, prompt: 'Select client...'}, { class: 'selectize', required: true }
+          = f.select :client_id, @clients.map { |client| [client.name, client.id] }, {selected: @event.client_id, prompt: 'Select client...'}, { class: 'selectize', required: true }
         .form-group.mr-3
-          = select_tag :service_line, options_for_select(@service_lines.sort, selected: @event.tag_list), include_blank: true, prompt: 'Select service line...', required: true, class: 'selectize'
+          = select_tag :service_line, options_for_select(@service_lines, selected: @event.tag_list), include_blank: true, prompt: 'Select service line...', required: true, class: 'selectize'
         .form-group.mr-3 
           = f.select :event_type_id, EventType.all.map { |key, value| [key.name, key.id] }.sort, {selected: @event.event_type_id, prompt: 'Select job nature...'}, { class: 'selectize', required: true }
         .form-group.mr-3
@@ -82,9 +82,9 @@ hr
                 td width="15%"
                   = f.date_field :start_time, { class: 'form-control', data: { event_id: event.id }, onchange: "eventsUpdate(this)" }
                 td width="20%"
-                  = f.select :client_id, @clients.map { |client| [client.name, client.id] }.sort, {selected: event.client_id, prompt: 'Select client...'}, { class: 'selectize', data: { event_id: event.id}, onchange: "eventsUpdate(this);" }
+                  = f.select :client_id, @clients.map { |client| [client.name, client.id] }, {selected: event.client_id, prompt: 'Select client...'}, { class: 'selectize', data: { event_id: event.id}, onchange: "eventsUpdate(this);" }
                 td width="20%"
-                  = f.select :tag_list, @service_lines.map { |sl| [sl, sl]}.sort, { selected: event.tags.last, prompt: 'Select service line...' }, { class: 'selectize', data: { event_id: event.id }, onchange: "eventsUpdate(this);" }
+                  = f.select :tag_list, @service_lines.map { |sl| [sl, sl]}, { selected: event.tags.last, prompt: 'Select service line...' }, { class: 'selectize', data: { event_id: event.id }, onchange: "eventsUpdate(this);" }
                 td width="20%"
                   = f.select :event_type_id, EventType.all.map {|event_type| [event_type.name, event_type.id]}.sort, {selected: event.event_type_id, prompt: 'Select job nature...'}, { class: 'selectize', data: { event_id: event.id }, onchange: "eventsUpdate(this)" }
                 td width="15%"


### PR DESCRIPTION
# Description
Simple fixes for timesheet as requested:
1. Remove job nature button from all users except staffers and admins
2. Sort dropdowns by alphabetical order
3. Allow all roles to generate timesheet
4. Rearrange table columns: "choose client first then service line then job nature"
5. "Create new task" section move to the top

Notion link: https://www.notion.so/{unique-id}

## Remarks
- Minor changes from Zhengxun's feedback. The rest requires more work, so its TBD.

# Testing
- Tested with an account of some random roles -> Can allocate user of random roles instead of previously just associate and consultant
- Checked alphabetical order of dropdowns and the rearrangement.
- Checked that only staffer and admin can see export and job nature button