### PR TITLE
Use update_columns to skip callback of template's after_update

### DIFF
--- a/lib/tasks/update.rake
+++ b/lib/tasks/update.rake
@@ -125,7 +125,7 @@ namespace :update do
   desc "Update existing templates with on-demand template pattern"
   task update_existing_template_to_on_demand: :environment do
     Template.where(template_pattern: nil).each do |t|
-      t.update(template_pattern: "on_demand")
+      t.update_columns(template_pattern: "on_demand")
     end
   end
 end


### PR DESCRIPTION
# Description
Issue:
- When running rake task to update templates with no template_pattern to on_demand template, it runs the callback after_update `update_workflow_actions` of template, which in turn created in-app notification of the next task. This is not good as it creates multiple notifications when running the rake task.

Solution:
- Use `update_columns` method to skip callbacks of template model

Notion link: https://www.notion.so/{unique-id}

## Remarks
- It's concerning that the after_update method `update_workflow_actions` calls another after_save method of the workflow_action model, which runs another callback called `trigger_next_task` -> resulting in creating an in-app notifications. Perhaps need to think of how to organise our callbacks?

# Testing
- Tested by setting the template pattern of company A's template to nil, run rake task and check that no in-app notifications are created.
