### PR TITLE
Add rake task to allocate symphony product for existing companies

### DIFF
--- a/lib/tasks/update.rake
+++ b/lib/tasks/update.rake
@@ -128,4 +128,15 @@ namespace :update do
       t.update_columns(template_pattern: "on_demand")
     end
   end
+
+  desc "Update existing companies with symphony product"
+  task existing_companies_with_symphony_product: :environment do
+    Company.where(products: nil).each do |c|
+      # Initialize products column as an array
+      c.products = []
+      # Push symphony into existing company's product
+      c.products << "Symphony"
+      c.save
+    end
+  end
 end


### PR DESCRIPTION
# Description
Add rake task to update the products column in existing companies.
- Existing companies should have symphony product
- Initialize the product column as an array, then push "Symphony" into the products column. (This is because the default value of [] in the migration file does not apply to existing records to the database)

Notion link: https://www.notion.so/Create-rake-task-to-allocate-products-to-existing-companies-038c3742c33143238ed43f338aa357b1

## Remarks
- Nil

# Testing
- Run `rake update:existing_companies_with_symphony_product` and check PSequal to ensure all existing companies has symphony in their products column