### PR TITLE
Removed json fields from admin page.

### DIFF
--- a/app/dashboards/company_dashboard.rb
+++ b/app/dashboards/company_dashboard.rb
@@ -30,11 +30,9 @@ class CompanyDashboard < Administrate::BaseDashboard
     access_secret: Field::String,
     expires_at: Field::Number,
     account_type: EnumField,
-    stripe_subscription_plan_data: Field::JSONB,
     before_deadline_reminder_days: Field::Number,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
-    products: Field::JSONB,
   }
 
   # COLLECTION_ATTRIBUTES
@@ -77,9 +75,7 @@ class CompanyDashboard < Administrate::BaseDashboard
     :access_secret,
     :expires_at,
     :account_type,
-    :stripe_subscription_plan_data,
     :before_deadline_reminder_days,
-    :products
   ]
 
   # Overwrite this method to customize how profiles are displayed


### PR DESCRIPTION
# Description

Administrate Field Jsonb gem kept adding extra escape characters to the json fields whenever there are updates, rendering the data saved in the database invalid.

## Remarks

Need to think of a workaround to enable editing of such fields through the admin page.

# Testing

Check in the /admin page that "Stripe Subscription Data" and "Products" json fields are no longer present.
