### PR TITLE
Fix setting workflow when invoice is sent to xero

### DIFF
--- a/app/controllers/symphony/workflows_controller.rb
+++ b/app/controllers/symphony/workflows_controller.rb
@@ -341,7 +341,7 @@ class Symphony::WorkflowsController < ApplicationController
   end
 
   def set_workflow
-    @workflow = policy_scope(Workflow).find_by(slug: params[:workflow_id])
+    @workflow = policy_scope(Workflow).find(params[:workflow_id])
     @documents = @company.documents.order(created_at: :desc)
     @document_templates = DocumentTemplate.where(template: @workflow.template)
   end

--- a/app/views/symphony/invoices/edit.html.slim
+++ b/app/views/symphony/invoices/edit.html.slim
@@ -45,8 +45,8 @@
             .row
               .col-md-12
                 / align buttons to the right
-                = link_to("Approve", xero_create_invoice_symphony_workflow_path(@workflow.template.slug, @workflow.friendly_id, payment: "payment", workflow_action_id: params[:workflow_action_id]), method: 'post', role: 'button', class: 'btn btn-success approve-button ml-2 float-right')
-                = link_to("Submit for approval", xero_create_invoice_symphony_workflow_path(@workflow.template.slug, @workflow.friendly_id, approved: "approved", workflow_action_id: params[:workflow_action_id]), method: 'post', role: 'button', class: 'btn btn-warning submit-approval-button ml-2 float-right')
+                = link_to("Approve", xero_create_invoice_symphony_workflow_path(@workflow.template.slug, @workflow.id, payment: "payment", workflow_action_id: params[:workflow_action_id]), method: 'post', role: 'button', class: 'btn btn-success approve-button ml-2 float-right')
+                = link_to("Submit for approval", xero_create_invoice_symphony_workflow_path(@workflow.template.slug, @workflow.id, approved: "approved", workflow_action_id: params[:workflow_action_id]), method: 'post', role: 'button', class: 'btn btn-warning submit-approval-button ml-2 float-right')
           - else
             - if policy(@invoice).reject?
               button type="button" class="btn btn-danger float-right mr-2" data-target="#remarkModal" data-toggle="modal" Reject


### PR DESCRIPTION
# Description
Error on my development when i try to send invoice to xero:
<img width="1440" alt="Screenshot 2020-09-24 at 4 27 22 PM" src="https://user-images.githubusercontent.com/40416736/94120865-374a2b80-fe83-11ea-9d81-9156a995c280.png">

- Change the way set_workflow is queried.

Notion link: https://www.notion.so/{unique-id}

## Remarks
Confused ><
- Rollbar error is: `TypeError: no implicit conversion of nil into String`, but i couldn't replicate the error after i fix the friendly_id issue, and it works well after fixing
- I attempted to query using the gem method `policy_scope(Workflow).friendly.find(params[:workflow_id])` but it didn't work... 

# Testing
- Tested by uploading multiple files, go through the whole invoice process and send over to xero's awaiting approval and awaiting payment
