### PR TITLE
Change friendly_id version to 5.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ gem 'acts_as_list'
 # For tagging
 gem 'acts-as-taggable-on', '~> 6.5.0'
 # Use user friendly slugs
-gem 'friendly_id', '~> 5.4.0'
+gem 'friendly_id', '5.3.0'
 # Amazon S3 SDK
 gem 'aws-sdk-s3', '~> 1.81.0'
 gem 'aws-sdk-textract', '~> 1.19.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,7 +248,7 @@ GEM
     foreman (0.87.2)
     formatador (0.2.5)
     foundation_emails (2.2.1.0)
-    friendly_id (5.4.0)
+    friendly_id (5.3.0)
       activerecord (>= 4.0.0)
     get_process_mem (0.2.5)
       ffi (~> 1.0)
@@ -669,7 +669,7 @@ DEPENDENCIES
   fog-aws
   font_awesome5_rails
   foreman
-  friendly_id (~> 5.4.0)
+  friendly_id (= 5.3.0)
   guard-rspec
   image_processing (~> 1.11.0)
   inky-rb


### PR DESCRIPTION
# Description
FriendlyID returning `ActiveRecord::RecordNotFound: can't find record with friendly id: "5XkhyZbBZRygCbAbIQWvby"` when click on daily summary email link.
- New version 5.4.0 could have change some method, from this PR: https://github.com/norman/friendly_id/issues/950
- Solution is to change version back to 5.3.0

Notion link: https://www.notion.so/{unique-id}

## Remarks
- nil

# Testing
- Tested by running daily summary email and click the task -> brings you to workflow SHOW page now
- Tested workflow INDEX and SHOW page are working fine
