### PR TITLE
Fix devise email typo for reset password and unlock account

### DIFF
--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -44,7 +44,7 @@ class CustomDeviseMailer < Devise::Mailer
           ],
           dynamic_template_data: {
             firstName: record.email,
-            confirmationToken: token
+            unlockToken: token
           }
         }
       ],
@@ -74,7 +74,7 @@ class CustomDeviseMailer < Devise::Mailer
           ],
           dynamic_template_data: {
             firstName: record.email,
-            confirmationToken: token
+            resetToken: token
           }
         }
       ],


### PR DESCRIPTION
# Description

Token variable name was confirmationToken, leading to sendgrid template getting no token when resetting password and unlocking acc.
Fix the typo

Notion link: https://www.notion.so/{unique-id}

## Remarks
- nil

# Testing
- Tested by resetting password on localhost
