### PR TITLE
Scope templates to show template without batches in sidebar

### DIFF
--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -25,6 +25,8 @@ class Template < ApplicationRecord
   validates :title, :slug, presence: true
 
   before_save :data_names_to_json
+  # Scope templates that have no batches. Only those that have no batches will be displayed in symphony sidebar
+  scope :has_no_batches, -> { includes(:batches).where(batches: { id: nil }) }
 
   def get_roles
     self.sections.map{|section| section.tasks.map(&:role)}.flatten.compact.uniq

--- a/app/views/layouts/_sidebar.html.slim
+++ b/app/views/layouts/_sidebar.html.slim
@@ -55,7 +55,8 @@
         = link_to symphony_templates_path, class: 'float-right' do
           i.material-icons-outlined add
         ul#routineMenu.collapse.list-unstyled
-          - ::Template.assigned_templates(current_user).each do |template|
+          / Calling template model scope to display templates with NO batches
+          - ::Template.assigned_templates(current_user).has_no_batches.each do |template|
             li.hover-blue.py-1.m-4
               = link_to template.title, symphony_workflows_path(template.slug), class: 'sidebar-font text-dark'
     hr


### PR DESCRIPTION
# Description
When clicked on routine that comes from batch upload, it will timeout due to a huge amount of workflows and also no pagination. To prevent that:
- Remove template with batches from symphony sidebar by scoping template to find templates with no batches only


Notion link: https://www.notion.so/{unique-id}

## Remarks
- Nil

# Testing
- Tested on multiple companies to see if sidebar will show templates with batches
