### PR TITLE
Overture profile index pagination

### DIFF
--- a/app/controllers/overture/profiles_controller.rb
+++ b/app/controllers/overture/profiles_controller.rb
@@ -5,6 +5,7 @@ class Overture::ProfilesController < ApplicationController
 
   def index
     @profiles = Profile.all
+    @profiles = Kaminari.paginate_array(@profiles).page(params[:page]).per(5)
   end
 
   def show

--- a/app/views/overture/profiles/index.html.slim
+++ b/app/views/overture/profiles/index.html.slim
@@ -37,3 +37,5 @@ hr
                       i.material-icons-outlined.p-0 bookmark_border
                     = link_to "View", overture_profile_path(profile.id), class: "btn btn-white border border-secondary text-primary mr-3"
                     = link_to "State Interest", overture_profile_state_interest_path(profile.id), class: "btn btn-primary mr-3"
+.mt-6
+  = paginate @profiles, views_prefix: 'dashboard'


### PR DESCRIPTION
# Description
<img width="1440" alt="Screenshot 2020-11-04 at 1 18 20 PM" src="https://user-images.githubusercontent.com/47408304/98072141-453a9580-1ea0-11eb-9984-e6ecf0798bab.png">
Add pagination to profile index (limit to 5 a page)

Notion link: https://www.notion.so/Show-all-startups-in-index-page-with-pagination-5017d24a3b104e81bbadcbc75f646001

## Remarks

# Testing
Pagination appears when more than 5 profiles are present.
Able to navigate between pages.
