### PR TITLE
Add user's contact number in state interest email

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -26,6 +26,7 @@ class NotificationMailer < ApplicationMailer
     mail(to: "enquiry@paloe.com.sg", from: 'Paloe Overture <admin@excide.co>', subject: 'TO SAM!', body: 'Some body',  template_id: ENV['SENDGRID_OVERTURE_STATED_INTEREST'], dynamic_template_data: {
         fullName: user.full_name,
         email: user.email,
+        contactNumber: user.contact_number,
         profileName: profile.name,
         url: profile.url, 
       }


### PR DESCRIPTION
# Description
- Add user's contact number in state interest email

Notion link: https://www.notion.so/{unique-id}

## Remarks
- Nik

# Testing
- Tested by sending a state interest email to myself, got the contact number as shown below:
<img width="652" alt="Screenshot 2020-11-05 at 3 24 20 PM" src="https://user-images.githubusercontent.com/40416736/98210103-0299bb80-1f7b-11eb-9755-b7ebad70424e.png">


