### PR TITLE
Fix workflow deadline for symphony

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -40,7 +40,7 @@ class Workflow < ApplicationRecord
   end
 
   def set_workflow_deadline
-    set_deadline(self.template, self, self.template.start_date.present? ? self.template.start_date : Date.current)
+    set_deadline(self.template, self, self.created_at.to_date)
   end
 
   # updates workflow and workflow actions' deadline based on its date of creation.
@@ -161,7 +161,7 @@ class Workflow < ApplicationRecord
       s.tasks.each do |t|
         # workflow actions of an unordered routine can be done in any order, so they are all current actions
         wfa = WorkflowAction.create!(task: t, completed: false, company: self.company, workflow: self, assigned_user_id: t.user_id.present? ? t.user_id : nil, current_action: self.template.unordered? ? true : false)
-        set_deadline(t, wfa, self.template.start_date.present? ? self.template.start_date : Date.current)
+        set_deadline(t, wfa, wfa.created_at.to_date)
       end
       # Automatically set first task as completed if workflow is part of a batch and first task is a file upload task
       s.tasks.first.get_workflow_action(self.company_id, self.id).update(completed: true) if (s.position == 1 && s.tasks.first.task_type == "upload_file" && self.batch.present?)


### PR DESCRIPTION
# Description
Issue:
<img width="1436" alt="Screenshot 2020-11-18 at 9 46 55 PM" src="https://user-images.githubusercontent.com/40416736/99538360-d4d75c80-29e7-11eb-93b8-c3e974999d13.png">

Due is the same no matter which cycle because `set_deadline` method takes in template's start_date. The start date will be the same no matter which cycle. 
Hence, I changed it to reference its own's created_at date. For eg, a workflow or workflow_action's deadline will be based on the created_at date to calculate the deadline.

Notion link: https://www.notion.so/{unique-id}

## Remarks
- Nil

# Testing
- Tested by creating a monthly routine. Change the created_at and deadline of the cycle to the previous month. Change template's next_workflow_date to current date. Run scheduler to create next workflow, and check if the due date is the same as the previous one.
- Tested on-demand routine to ensure the deadline is set correctly as well.
- Tested on daily routine.
