### PR TITLE
Hide create folder button in view if within a folder

### DIFF
--- a/app/views/motif/documents/index.html.slim
+++ b/app/views/motif/documents/index.html.slim
@@ -1,22 +1,24 @@
 .row.mb-3.mt-5.ml-3
   .col-sm-12
-    button.btn.btn-primary.float-right.ml-5 data-target="#newFolderUpload" data-toggle="modal" type="button" Create Folder
-    #newFolderUpload.modal.fade aria-hidden="true" aria-labelledby="newMotifFolderUpload" role="dialog" tabindex="-1"
-      .modal-dialog role="document"
-        .modal-content
-          .modal-header
-            h5#newMotifFolderUpload.modal-title Create new folder
-            button.close aria-label="Close" data-dismiss="modal" type="button"
-              span aria-hidden="true"  &times;
-          .modal-body
-            = form_for(@folder, url: motif_folders_path, html: { method: :post }) do |f|
-              .row.mt-3
-                .col-md-12
-                  .form-group
-                    = f.text_field :name, placeholder: 'New folder', class: 'form-control'
-              .row
-                .col-md-12
-                  = f.submit "Save", class: 'btn btn-sm btn-primary float-right'
+    / Don't allow create folder button to be shown if within a folder
+    - unless controller_name == 'folders'
+      button.btn.btn-primary.float-right.ml-5 data-target="#newFolderUpload" data-toggle="modal" type="button" Create Folder
+      #newFolderUpload.modal.fade aria-hidden="true" aria-labelledby="newMotifFolderUpload" role="dialog" tabindex="-1"
+        .modal-dialog role="document"
+          .modal-content
+            .modal-header
+              h5#newMotifFolderUpload.modal-title Create new folder
+              button.close aria-label="Close" data-dismiss="modal" type="button"
+                span aria-hidden="true"  &times;
+            .modal-body
+              = form_for(@folder, url: motif_folders_path, html: { method: :post }) do |f|
+                .row.mt-3
+                  .col-md-12
+                    .form-group
+                      = f.text_field :name, placeholder: 'New folder', class: 'form-control'
+                .row
+                  .col-md-12
+                    = f.submit "Save", class: 'btn btn-sm btn-primary float-right'
     button.btn.btn-primary.float-right.ml-5 data-target="#newMotifDocUploads" data-toggle="modal" type="button"
       i.material-icons-outlined.text-white add
       | Upload Documents


### PR DESCRIPTION
# Description

- Prevent creating more than 1 level of folders currently by hiding the create folder button if the view is loaded inside an existing folder.

Notion link: https://www.notion.so/{unique-id}

## Remarks

- None

# Testing

- Check the page when in documents index view and make sure create folder button is showing
- Check the page when in folders show view and make sure create folder button is not showing
