### PR TITLE
Fix going to error page when user goes to motif URL without logged in

### DIFF
--- a/app/controllers/motif/companies_controller.rb
+++ b/app/controllers/motif/companies_controller.rb
@@ -1,7 +1,9 @@
 class Motif::CompaniesController < ApplicationController
   layout 'motif/application'
-  
+
+  before_action :authenticate_user!
   before_action :set_company
+  
   def edit
     build_addresses
   end

--- a/app/controllers/motif/franchisees_controller.rb
+++ b/app/controllers/motif/franchisees_controller.rb
@@ -1,6 +1,7 @@
 class Motif::FranchiseesController < ApplicationController
   layout 'motif/application'
   
+  before_action :authenticate_user!
   before_action :set_company
   before_action :set_franchisee, except: :index
 

--- a/app/controllers/motif/home_controller.rb
+++ b/app/controllers/motif/home_controller.rb
@@ -1,8 +1,8 @@
 class Motif::HomeController < ApplicationController
   layout 'motif/application'
   
-  before_action :set_company
   before_action :authenticate_user!
+  before_action :set_company
 
   def index
     @franchisees = Franchisee.includes(:company).where(company_id: @company.id)

--- a/app/controllers/motif/notes_controller.rb
+++ b/app/controllers/motif/notes_controller.rb
@@ -1,6 +1,7 @@
 class Motif::NotesController < ApplicationController
   layout 'motif/application'
 
+  before_action :authenticate_user!
   before_action :get_outlet, except: :communication_hub
   before_action :update_last_click_into_comm_hub, except: :create
 

--- a/app/controllers/motif/outlets_controller.rb
+++ b/app/controllers/motif/outlets_controller.rb
@@ -1,6 +1,7 @@
 class Motif::OutletsController < ApplicationController
   layout 'motif/application'
   
+  before_action :authenticate_user!
   before_action :set_company
   before_action :set_company_roles
   before_action :set_outlet, only: [:new, :edit, :update, :show]

--- a/app/controllers/motif/workflows_controller.rb
+++ b/app/controllers/motif/workflows_controller.rb
@@ -1,5 +1,7 @@
 class Motif::WorkflowsController < ApplicationController
   layout 'motif/application'
+  
+  before_action :authenticate_user!
   before_action :set_company
   before_action :set_workflow, only: [:show, :update, :destroy]
 


### PR DESCRIPTION
# Description
- The authenticate_user! method was before the before_action
- Add missing authenticate_user! in motif controllers

Notion link: https://www.notion.so/Error-page-when-user-goes-to-motif-URL-when-not-logged-in-57f13f7da0364cafbfa6dab64190349e

## Remarks
- nil

# Testing
- Checked all motif pages without logging in. Should redirect to login page instead of error page
