### PR TITLE
Add breadcrumb to folders

### DIFF
--- a/app/views/motif/documents/index.html.slim
+++ b/app/views/motif/documents/index.html.slim
@@ -77,7 +77,16 @@
         = button_tag 'Apply filters', type: 'button', class: 'btn btn-primary documents-filter-button'
       span.align-items-center.ml-5.text-primary#clear-filter style="cursor: pointer;"
         | Clear
-  hr
+  - if controller_name == "folders"
+    hr.mb-2
+    .row.ml-4
+      .col
+        ul.breadcrumb.breadcrumb-transparent.breadcrumb-arrow.font-weight-bold.p-0.my-2.font-size-sm
+          li.breadcrumb-item
+            = link_to "Repository", motif_documents_path, class: "text-dark"
+          li.breadcrumb-item
+            = @folder.name
+  hr.mt-2
   table.table.ml-4
     thead
       tr

--- a/app/webpacker/src/stylesheets/metronic/motif/documents.scss
+++ b/app/webpacker/src/stylesheets/metronic/motif/documents.scss
@@ -19,3 +19,28 @@ input.remark-border:focus {
   font-size: 15px !important;
   border-radius: 0 !important;
 }
+
+// CSS for breadcrumb in folders
+.breadcrumb-arrow {
+  .breadcrumb-item {
+    &:before {
+      display: none;
+    }
+
+    &:after {
+      display: block;
+      content: ">";
+      margin-left: $breadcrumb-item-padding;
+    }
+
+    &:last-child {
+      &:before {
+        display: none;
+      }
+      &:after {
+        display: none;
+      }
+      font-weight: 700;
+    }
+  }
+}


### PR DESCRIPTION
# Description
<img width="1439" alt="Screenshot 2020-12-10 at 8 58 58 PM" src="https://user-images.githubusercontent.com/47408304/101775504-891d5c00-3b2a-11eb-87ec-2e96a62f7caa.png">
Add link to documents index and display current folder name.

Notion link: https://www.notion.so/Breadcrumb-in-dataroom-to-indicate-folder-structure-e0eefcbe0c71494ab367299605da6104

## Remarks
Does not work for nested folders

# Testing
Check different folders
