### PR TITLE
Add check to motif user settings to update details without password

### DIFF
--- a/app/controllers/motif/users_controller.rb
+++ b/app/controllers/motif/users_controller.rb
@@ -53,6 +53,10 @@ class Motif::UsersController < ApplicationController
   end
 
   def update
+    if params[:user][:password].blank? && params[:user][:password_confirmation].blank?
+      params[:user].delete(:password)
+      params[:user].delete(:password_confirmation)
+    end
     if @user.update(user_params)
       redirect_to edit_motif_user_path(@user), notice: 'User successfully updated!'
     else


### PR DESCRIPTION
# Description

Fix cannot update user details for Motif
Don't need to provide password to change details now

## Remarks

Took quite awhile figuring out devise

# Testing

Update user details from My Account page in settings (Contact number)