### PR TITLE
Refactor authorization codes and remove unused methods

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,15 +40,7 @@ class ApplicationController < ActionController::Base
   def user_not_authorized(exception)
     policy_name = exception.policy.class.to_s.underscore
     flash[:alert] = t "#{policy_name}.#{exception.query}", scope: "pundit", default: :default
-    # If company only has 1 product, fallback to that product root path
-    if current_user.company.products.length == 1
-      redirect_back(fallback_location: "/#{current_user.company.products[0]}")
-    # Investor will fallback to overture_root_path is product not found
-    elsif current_user.has_role?(:investor, current_user.company)
-      redirect_back(fallback_location: overture_root_path)
-    else
-      redirect_back(fallback_location: root_path)
-    end
+    redirect_back(fallback_location: root_path)
   end
 
   def xero_login
@@ -86,11 +78,8 @@ class ApplicationController < ActionController::Base
 
   # Checks the controller parent and check if the user has access to the product based on application policy unless parent is users (login) or object (not namespaced)
   def authenticate_product
-    # Check if user is logged in before authorizing products to prevent authorization outside of current_user
-    if user_signed_in?
-      product = controller_path.split('/').first
-      authorize current_user, ("has_" + product + "?").to_sym unless product == "users" || product == "companies"
-    end
+    product = self.class.parent.to_s.downcase
+    authorize current_user, ("has_" + product + "?").to_sym unless product == "users" || product == "object"
   end
 
   def set_company

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -35,17 +35,12 @@ class ApplicationPolicy
     false
   end
 
-  def has_home?
-    # Check if company has more than 1 product before authorizing them to product page
-    (user.company.products.length > 1) and user_not_investor?
-  end
-
   def has_symphony?
-    user.company.products.include? 'symphony' and user_not_investor?
+    user.company.products.include? 'symphony'
   end
 
   def has_motif?
-    user.company.products.include? 'motif' and user_not_investor?
+    user.company.products.include? 'motif'
   end
 
   def has_overture?
@@ -53,7 +48,7 @@ class ApplicationPolicy
   end
 
   def has_conductor?
-    user.company.products.include? 'conductor' and user_not_investor?
+    user.company.products.include? 'conductor'
   end
 
   def scope
@@ -100,11 +95,5 @@ class ApplicationPolicy
 
       return has_permission
     end
-  end
-
-  private
-  def user_not_investor?
-    # Investor should only be able to login to overture and not other product
-    !user.has_role?(:investor, record.company)
   end
 end


### PR DESCRIPTION
# Description
- Remove checks in pundit if user is an investor
- Change authorize line to `authorize current_user, ("has_" + product + "?").to_sym unless product == "users" || product == "object"`. Using `product == "users" || "object"` returns the string "object" if product is not users, which doesn't authorize the code as unless expects a boolean value (I think that's why I changed the code in the first place). A quick fix is to do `unless product == "users" || product == "object"` since currently only 2 types of products.

Notion link: https://www.notion.so/{unique-id}

## Remarks
- Need to take notes that users are able to access product page.

# Testing
- Tested with an account with just motif. It will not give me access if I enter into other products.
- Tested with an account with multiple products. It will not give me access to products that i do not have
