### PR TITLE
[WIP] Agreement documents to display across franchisor and franchisee

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -116,7 +116,11 @@ class CompaniesController < ApplicationController
 
   def set_default_franchisee
     # By default, create franchisee record when creating the entity (company) and set franchisee type as master franchisee
-    Franchisee.create(franchise_licensee: @company.name, company_id: @company.parent.id, license_type: "master_franchisee")
+    @franchisee = Franchisee.create(franchise_licensee: @company.name, company_id: @company.parent.id, license_type: "master_franchisee")
+    # Create a folder in doc repo to store all retrospective uploaded files for franchisee
+    @folder = Folder.create(name: "Agreement documents - #{@franchisee.franchise_licensee}", company: @company.parent, franchisee: @franchisee)
+    # Give permission access to the person that created the franchisee
+    Permission.create(user: current_user, can_write: true, can_download: true, can_view: true, permissible: @folder)
   end
 
   def remove_company_roles

--- a/app/controllers/folders_controller.rb
+++ b/app/controllers/folders_controller.rb
@@ -86,7 +86,7 @@ class FoldersController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_folder
-      @folder = policy_scope(Folder).find(params[:id])
+      @folder = Folder.find(params[:id])
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/controllers/motif/documents_controller.rb
+++ b/app/controllers/motif/documents_controller.rb
@@ -1,5 +1,6 @@
 class Motif::DocumentsController < ApplicationController
   layout 'motif/application'
+  include Motif::DocumentsHelper
   
   before_action :authenticate_user!
   before_action :set_company
@@ -10,7 +11,7 @@ class Motif::DocumentsController < ApplicationController
 
   def index
     @folder = Folder.new
-    @folders = policy_scope(Folder).roots
+    @folders = get_folders(@company)
     @documents = policy_scope(Document).where(folder_id: nil).order(created_at: :desc).includes(:permissions)
     @users = @company.users.includes(:permissions)
     @activities = PublicActivity::Activity.order("created_at desc").where(trackable_type: "Document").first(10)
@@ -121,6 +122,6 @@ class Motif::DocumentsController < ApplicationController
   end
 
   def set_document
-    @document = @company.documents.find(params[:id])
+    @document = Document.find(params[:id])
   end
 end

--- a/app/controllers/motif/folders_controller.rb
+++ b/app/controllers/motif/folders_controller.rb
@@ -23,7 +23,7 @@ class Motif::FoldersController < FoldersController
     @users = @company.users.includes(:permissions)
     @folders = policy_scope(Folder).children_of(@folder)
     @activities = PublicActivity::Activity.order("created_at desc").where(trackable_type: "Document").first(10)
-    @documents = policy_scope(Document).where(folder: @folder)
+    @documents = Document.where(folder: @folder)
 
     render "motif/documents/index"
   end

--- a/app/controllers/motif/franchisees_controller.rb
+++ b/app/controllers/motif/franchisees_controller.rb
@@ -47,10 +47,8 @@ class Motif::FranchiseesController < ApplicationController
     if params[:successful_files].present?
       # Get franchisee
       @franchisee = @company.franchisees.find_by(id: params[:franchisee_id])
-      # Create a folder in doc repo to store all the uploaded files
-      @folder = Folder.find_or_create_by(name: "Agreement documents - #{@franchisee.franchise_licensee}", company: @company)
-      # Give permission access to the person that uploaded the folder
-      Permission.find_or_create_by(user: current_user, can_write: true, can_download: true, can_view: true, permissible: @folder)
+      # Find folder
+      @folder = @company.folders.find_by(name: "Agreement documents - #{@franchisee.franchise_licensee}")
       @files = []
       parsed_files = JSON.parse(params[:successful_files])
       parsed_files.each do |file|

--- a/app/helpers/motif/documents_helper.rb
+++ b/app/helpers/motif/documents_helper.rb
@@ -1,0 +1,11 @@
+module Motif::DocumentsHelper
+  def get_folders(company)
+    # Get documents that are related to franchisees but are link to parent company
+    @franchisee = company.parent.franchisees.find_by(franchise_licensee: company.name) if company.parent.present?
+    if @franchisee.present?
+      @folders = policy_scope(Folder).roots + @franchisee.folders
+    else
+      @folders = policy_scope(Folder).roots
+    end
+  end
+end

--- a/app/models/folder.rb
+++ b/app/models/folder.rb
@@ -2,6 +2,7 @@ class Folder < ApplicationRecord
   has_ancestry primary_key_format: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
 
   belongs_to :company
+  belongs_to :franchisee
   belongs_to :user
 
   has_many :documents, dependent: :destroy

--- a/app/models/franchisee.rb
+++ b/app/models/franchisee.rb
@@ -1,7 +1,9 @@
 class Franchisee < ApplicationRecord  
   belongs_to :company
-  has_many :outlets, dependent: :destroy
+
   has_many :documents, dependent: :destroy
+  has_many :folders, dependent: :destroy
+  has_many :outlets, dependent: :destroy
 
   enum renewal_period_freq_unit: {days: 0, weeks: 1, months: 2, years: 3}
   enum license_type: { master_franchisee: 0, area_franchisee: 1, unit_franchisee: 2}

--- a/app/views/motif/franchisees/agreements.html.slim
+++ b/app/views/motif/franchisees/agreements.html.slim
@@ -9,7 +9,7 @@
           | Upload relevant documents for franchisee to see.
     hr.mb-3
     .dashboard-body.align-item-center.motifUploadFranchiseeDocuments.my-5#Dashboard data-franchisee="#{params[:franchisee_id]}"
-    h6.my-5 Documents Uploaded
+    h6.my-5 Documents Uploaded:
     - @documents.each do |d|
       .row.mb-3.my-5
         .col-sm-6

--- a/app/views/motif/franchisees/edit.html.slim
+++ b/app/views/motif/franchisees/edit.html.slim
@@ -18,7 +18,7 @@
             = f.text_field :registered_address, placeholder: "Registered address", class: 'form-control col-sm-10'
           .form-group
             = f.label :license_type, "License Type", class: "label-bold"
-            = f.select :license_type, Franchisee.license_types.map { |key, value| [key.titleize, key] },  {selected: @franchisee.license_type}, class: 'form-control col-sm-10'
+            = f.select :license_type, Franchisee.license_types.map { |key, value| [key.titleize, key] },  {include_blank: true, selected: @franchisee.license_type}, class: 'form-control col-sm-10'
           .form-group
             = f.label :commencement_date, class: "col-sm-5 pl-0 label-bold"
             = f.label :expiry_date, class: "col-sm-5 pl-2 label-bold"

--- a/app/views/motif/franchisees/show.html.slim
+++ b/app/views/motif/franchisees/show.html.slim
@@ -13,7 +13,7 @@
         .col-sm-3
           .font-weight-boldest = franchisee&.franchise_licensee
         .col-sm-3
-          .label.label-pill.label-inline.text-dark.p-3 class="label-motif-#{franchisee.license_type}" = franchisee&.license_type.titleize
+          .label.label-pill.label-inline.text-dark.p-3 class="label-motif-#{franchisee.license_type}" = franchisee&.license_type&.titleize
         .col-sm-5
           span.offset-sm-6 = pluralize(franchisee.outlets.length, "outlet")
       hr

--- a/db/migrate/20201223080220_add_franchisee_ref_to_folders.rb
+++ b/db/migrate/20201223080220_add_franchisee_ref_to_folders.rb
@@ -1,0 +1,5 @@
+class AddFranchiseeRefToFolders < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :folders, :franchisee, type: :uuid, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_22_103816) do
+ActiveRecord::Schema.define(version: 2020_12_23_080220) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -282,7 +282,9 @@ ActiveRecord::Schema.define(version: 2020_12_22_103816) do
     t.text "remarks"
     t.bigint "user_id"
     t.uuid "company_id"
+    t.uuid "franchisee_id"
     t.index ["ancestry"], name: "index_folders_on_ancestry"
+    t.index ["franchisee_id"], name: "index_folders_on_franchisee_id"
     t.index ["user_id"], name: "index_folders_on_user_id"
   end
 
@@ -793,6 +795,7 @@ ActiveRecord::Schema.define(version: 2020_12_22_103816) do
   add_foreign_key "events", "companies"
   add_foreign_key "events", "users", column: "staffer_id"
   add_foreign_key "folders", "companies"
+  add_foreign_key "folders", "franchisees"
   add_foreign_key "folders", "users"
   add_foreign_key "franchisees", "companies"
   add_foreign_key "invoices", "companies"


### PR DESCRIPTION
# Description
This PR is for franchisor to upload retrospective documents in their respective franchisee listing.
- Uploaded files will go into the agreement folder that was created when master franchisee is created
- The documents & folder will appear on both franchisor's and master franchisee's document repository

Notion link: https://www.notion.so/Update-franchise-structure-for-ADA-15ea83667f6c491b98b68962e54154f5

## Remarks
I am stuck on this problem as I don't know if it make sense for retrospective documents to appear on both companies (as master franchisee is link to a company record as well). It makes the permission setting for the agreement folder very difficult, or whether is it possible.

@hschin can you advise me on this? Not sure if I even want to merge this branch.

# Testing

[Please describe the tests that you used to verify your changes. Provide instructions so that the tests can be reproduced.]
