### PR TITLE
Fix master franchisee not able to upload

### DIFF
--- a/app/controllers/motif/documents_controller.rb
+++ b/app/controllers/motif/documents_controller.rb
@@ -25,7 +25,8 @@ class Motif::DocumentsController < ApplicationController
 
   def new
     @folders = policy_scope(Folder).roots
-    @workflow_action = @company.workflow_actions.find(params[:workflow_action_id]) if params[:workflow_action_id].present?
+    company_scope = @company.has_parent? ? [@company, @company.parent] : @company
+    @workflow_action = WorkflowAction.where(company_id: company_scope).find(params[:workflow_action_id])
     @folder_id = params[:folder_id]
     @document = Document.new
     authorize @document

--- a/app/views/motif/documents/new.html.slim
+++ b/app/views/motif/documents/new.html.slim
@@ -4,5 +4,3 @@
       h1.card-header Upload New Documents
       .card-body
         .dashboard-body.motifWorkflowActionMultipleUploads#Dashboard data-workflow="#{@workflow_action.workflow.id}" data-wfa="#{@workflow_action.id}"
-        
-


### PR DESCRIPTION
# Description

Master franchisee cannot upload documents within the task. This is because the wfa params is queried through its current_company, but wfa belongs to it's parent company (the franchise company)
Condition it to find wfa from company.parent

Notion link: https://www.notion.so/{unique-id}

## Remarks
- NIl
# Testing
- tested with unit franchisee, franchisor and MF account. Should be able to access document NEW page
