### PR TITLE
Fix company logo in header

### DIFF
--- a/app/views/layouts/motif/_motif_header.html.slim
+++ b/app/views/layouts/motif/_motif_header.html.slim
@@ -6,7 +6,7 @@
     = link_to motif_root_path, class: "navbar-brand" do
       = image_pack_tag("media/src/images/motif/ADA-logo.png", class: "motif-company-logo mr-5")
       - if current_user.company.company_logo.attached?
-        = image_tag(current_user.company.company_logo, class: "motif-company-logo")
+        = image_tag(current_user.company.company_logo.variant(resize: "200"), height: "45")
       - else
         i.material-icons-outlined.align-middle.mt-3 home
     ul.navbar-nav


### PR DESCRIPTION
# Description
<img width="1440" alt="Screenshot 2021-01-20 at 3 00 18 PM" src="https://user-images.githubusercontent.com/47408304/105139288-147a0c00-5b31-11eb-8bf1-882ec4d8f947.png">

Fix the height of the company logo in motif header

Notion link: https://www.notion.so/Change-logo-display-aspect-ratio-in-header-to-1-1-28c47ef984024f45b78032796c0c0a9f

# Testing
Tested with 
![bistro-cafe-logo-badge-with-calligraphy-vector-22824190](https://user-images.githubusercontent.com/47408304/105139329-2360be80-5b31-11eb-8d69-751f8db95fa1.jpg)
![ditto squirtle (1)](https://user-images.githubusercontent.com/47408304/105139337-25c31880-5b31-11eb-937d-0e718db8a274.jpg)
![franchise aw](https://user-images.githubusercontent.com/47408304/105139339-26f44580-5b31-11eb-920c-cc872756e5b9.jpeg)
![little_c-logo](https://user-images.githubusercontent.com/47408304/105139342-278cdc00-5b31-11eb-9327-68503b968d58.png)

