### PR TITLE
Change "to" email

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -23,7 +23,7 @@ class NotificationMailer < ApplicationMailer
   end
 
   def overture_notification(user, profile)
-    mail(to: "enquiry@paloe.com.sg", from: 'Paloe Overture <support@paloe.com.sg>', subject: 'TO SAM!', body: 'Some body',  template_id: ENV['SENDGRID_OVERTURE_STATED_INTEREST'], dynamic_template_data: {
+    mail(to: "support@paloe.com.sg", from: 'Paloe Overture <support@paloe.com.sg>', subject: 'TO SAM!', body: 'Some body',  template_id: ENV['SENDGRID_OVERTURE_STATED_INTEREST'], dynamic_template_data: {
         fullName: user.full_name,
         email: user.email,
         contactNumber: user.contact_number,


### PR DESCRIPTION
# Description

Change overture state interest email "to" recipient to support@paloe.com.sg
Notion link: https://www.notion.so/{unique-id}

## Remarks

# Testing

Sent the email to support@paloe.com.sg
