### PR TITLE
Change @users to department's users

### DIFF
--- a/app/controllers/conductor/events_controller.rb
+++ b/app/controllers/conductor/events_controller.rb
@@ -253,7 +253,7 @@ class Conductor::EventsController < ApplicationController
     @general_clients = Category.where(category_type: "client", department: nil)
     @general_tasks = Category.where(category_type: "task", department: nil)
     # Get users who have roles consultant, associate and staffer so that staffer can allocate these users
-    @users = User.joins(:roles).where({roles: {name: ["consultant", "associate", "staffer"], resource_id: @company.id}}).uniq.sort_by(&:first_name)
+    @users = User.where(department: @department)
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.


### PR DESCRIPTION
# Description

Changed @users variable to department's users so that the dropdown options are department's users.

Notion link: https://www.notion.so/{unique-id}

## Remarks

I think we do not need the associate/consultant stuff anymore right
@Jonathanlau92 
@hschin 

# Testing

Department's users are displayed as options in the dropdowns.
Can create new timesheet events.
Can filter events by user.
