### PR TITLE
Update active storage when upgrading rails to 6.1

### DIFF
--- a/db/migrate/20210305024012_add_service_name_to_active_storage_blobs.active_storage.rb
+++ b/db/migrate/20210305024012_add_service_name_to_active_storage_blobs.active_storage.rb
@@ -1,0 +1,18 @@
+# This migration comes from active_storage (originally 20190112182829)
+class AddServiceNameToActiveStorageBlobs < ActiveRecord::Migration[6.0]
+  def up
+    unless column_exists?(:active_storage_blobs, :service_name)
+      add_column :active_storage_blobs, :service_name, :string
+
+      if configured_service = ActiveStorage::Blob.service.name
+        ActiveStorage::Blob.unscoped.update_all(service_name: configured_service)
+      end
+
+      change_column :active_storage_blobs, :service_name, :string, null: false
+    end
+  end
+
+  def down
+    remove_column :active_storage_blobs, :service_name
+  end
+end

--- a/db/migrate/20210305024013_create_active_storage_variant_records.active_storage.rb
+++ b/db/migrate/20210305024013_create_active_storage_variant_records.active_storage.rb
@@ -1,0 +1,12 @@
+# This migration comes from active_storage (originally 20191206030411)
+class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
+  def change
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_03_235448) do
+ActiveRecord::Schema.define(version: 2021_03_05_024013) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -56,7 +56,14 @@ ActiveRecord::Schema.define(version: 2021_02_03_235448) do
     t.bigint "byte_size", null: false
     t.string "checksum", null: false
     t.datetime "created_at", null: false
+    t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
   create_table "activities", id: :serial, force: :cascade do |t|
@@ -840,6 +847,7 @@ ActiveRecord::Schema.define(version: 2021_02_03_235448) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "allocations", "availabilities"
   add_foreign_key "allocations", "events"
   add_foreign_key "allocations", "users"


### PR DESCRIPTION
# Description
When upgrading to rails 6.1, activestorage fails all files upload as an extra service_name column is added. This is stated in the release note: https://guides.rubyonrails.org/6_1_release_notes.html#active-storage-notable-changes
- To fix this, I ran `rails active_storage:update` to generate the 2 new migration file for active storage blob table (Solution is found here: https://stackoverflow.com/questions/58373159/unknown-attribute-service-name-for-activestorageblob)

Notion link: https://www.notion.so/{unique-id}

## Remarks
- Nil

# Testing
- Tested uploading multiple file in overture dataroom and upload in symphony document repository to check if uploading pass across different product