### PR TITLE
Validate outlets has no workflow of template_type before getting it

### DIFF
--- a/app/controllers/motif/workflows_controller.rb
+++ b/app/controllers/motif/workflows_controller.rb
@@ -15,7 +15,7 @@ class Motif::WorkflowsController < ApplicationController
     @templates = Template.includes(:company, :workflows).where(company_id: @company.id, template_type: @template_type).where(workflows: {id: nil})
     # Get workflows based on condition in workflow helper method
     @workflows = get_workflows(current_user, @template_type)
-    @outlets = get_outlets_by_type(nil, @company)
+    @outlets = get_outlets_that_has_no_workflows(@template_type, @company)
     @workflow = Workflow.new
   end
 

--- a/app/helpers/motif/outlets_helper.rb
+++ b/app/helpers/motif/outlets_helper.rb
@@ -14,4 +14,17 @@ module Motif::OutletsHelper
       Outlet.includes(:company).where(company_id: company).order("created_at asc") + company.children.includes(outlets: [:franchisee]).where(outlets: { franchisees: { franchise_licensee: ""}}).map(&:outlets).flatten
     end
   end
+
+  def get_outlets_that_has_no_workflows(template_type, company)
+    # Check if workflow of a particular template_type exists
+    workflows = Workflow.includes(:template).where(company: company, templates: { template_type: template_type })
+    # This checks for parent workflows, as direct owned outlet are usually created by parent company (for eg, franchisor onboards for it's franchisee). We will need to exclude these workflow's outlets so that it would not appear in the franchisee's dropdown
+    parent_workflows = Workflow.includes(:template).where(company: company.parent, templates: { template_type: template_type })
+    # If workflow of that template_type exists, then we will exclude outlets in the dropdown when creating workflows using the array method excluding given in Rails 6
+    if workflows.present?
+      (company.outlets + company.children.includes(outlets: [:franchisee]).where(outlets: { franchisees: { franchise_licensee: ""}}).map(&:outlets).flatten).excluding(workflows.map(&:outlet))
+    else
+      (company.outlets + company.children.includes(outlets: [:franchisee]).where(outlets: { franchisees: { franchise_licensee: ""}}).map(&:outlets).flatten).excluding(parent_workflows.map(&:outlet))
+    end
+  end
 end


### PR DESCRIPTION
# Description
Issue:
- A user can onboard an outlet multiple times despite templates being hidden from the dropdown as they can still use other templates. 
- A better solution would be to remove outlet which already have a workflow with that particular template_type

Notion link: https://www.notion.so/Validate-user-s-onboarding-for-ADA-bb21c7e11f6045fbaebea99202441e8f

## Remarks
- Nil

# Testing
- Tested with franchisor account and master franchisee account. Both accounts have both direct-owned and franchised outlets. It should show that the outlet are gone from the dropdown if a workflow is created out of it. 
- Also, the choose outlet dropdown should be distinct between template_type, meaning onboarding won't affect site_audit etc
