### PR TITLE
Revamp dashboard QnA styling and add activity history for QnA

### DIFF
--- a/app/controllers/overture/home_controller.rb
+++ b/app/controllers/overture/home_controller.rb
@@ -11,7 +11,7 @@ class Overture::HomeController < ApplicationController
     @need_approval = Topic.where(company: @company, status: "need_approval")
     @answered = Topic.where(company: @company, status: "answered")
     @closed = Topic.where(company: @company, status: "closed")
-    @activities = nil
+    @activities = PublicActivity::Activity.includes(:owner, :recipient).order("created_at desc").where(trackable_type: "Note").where(recipient_type: "Company", recipient_id: @company.id)
   end
 
   def financial_performance

--- a/app/controllers/overture/topics/notes_controller.rb
+++ b/app/controllers/overture/topics/notes_controller.rb
@@ -23,10 +23,13 @@ class Overture::Topics::NotesController < Overture::NotesController
     end
     @note.notable = @topic
     if @note.save and @topic.save
-      # Send need approval notification to all admin of the company
-      current_user.company.users.with_role(:admin, current_user.company).each do |user|
-        # Only send email notification if user with member role answer the question (Don't send email if admin answers)
-        NotificationMailer.need_approval_notification(user, @topic, @note).deliver_later if current_user.has_role?(:member, current_user.company)
+      # Create activity history for QnA answers
+      @note.create_activity key: 'note.qna_replies', owner: current_user, recipient: current_user.company,  params:{ topic_subject: @topic.subject_name, note_content: @note.content }
+      # Only send email notification to all admins of the company if user with member role answer the question (Don't send email if admin answers)
+      if current_user.has_role?(:member, current_user.company)
+        current_user.company.users.with_role(:admin, current_user.company).each do |user|
+          NotificationMailer.need_approval_notification(user, @topic, @note).deliver_later
+        end
       end
       redirect_to overture_topic_notes_path(topic_id: @topic.id), notice: "Answer has been posted. Please wait for answer to be approved."
     else

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,4 +1,6 @@
 class Note < ApplicationRecord
+  include PublicActivity::Model
+
   belongs_to :notable, polymorphic: true
   belongs_to :user
   belongs_to :workflow_action

--- a/app/views/overture/home/index.html.slim
+++ b/app/views/overture/home/index.html.slim
@@ -3,8 +3,8 @@
     .col-sm-12.text-left.ml-5
       h1.text-dark.font-weight-boldest Welcome, #{current_user.full_name}
       p.text-dark.lead It always seems impossible until it’s done. - Nelson Mandela
-.row.mt-5
-  .col-sm-4.ml-5.qna-wrapper.px-5.py-3
+.row.mt-5.d-block
+  .col-sm-4.ml-5.qna-wrapper.px-5.py-3.float-left
     .row.mt-5
       .col-sm-12
         h3 Q&A
@@ -28,17 +28,14 @@
         h1.font-weight-boldest = @closed.length
       .col-sm-5.mt-1
         .font-weight-boldest.badge.badge-pill.closed-text.float-right.p-3 Closed Question
-  .col-sm-7.ml-5.qna-wrapper
+  .col-sm-7.ml-5.qna-wrapper.float-left
     .row.mt-5
       .col-sm-12
         h3 Activity History
     - if @activities.present?
       - @activities.each do |activity|
         .row
-          .col-md-1
-            .d-flex.align-items-center.mb-10
-              = image_pack_tag 'media/src/images/overture/user-avatar-placeholder.jpg', class: 'icon-size dropdown-pointer mt-2'
-          .col-md-11
+          .col-md-12
             .d-flex.flex-column.mt-3
               = render_activities activity
     - else

--- a/app/views/public_activity/note/_qna_replies.html.slim
+++ b/app/views/public_activity/note/_qna_replies.html.slim
@@ -1,0 +1,8 @@
+.row.my-2
+  .col-md-1
+    = image_pack_tag 'media/src/images/symphony/user-avatar-placeholder.jpg', class: 'user-avatar-activity mt-2'
+  .col-sm-11
+    .row
+      .activity-description = "#{activity.owner&.full_name or 'Unknown'} replied #{activity.parameters[:topic_subject]}."
+    .row
+      = "#{activity.created_at.strftime("%d %b %Y")}"

--- a/app/webpacker/src/stylesheets/metronic/overture/home.scss
+++ b/app/webpacker/src/stylesheets/metronic/overture/home.scss
@@ -51,3 +51,13 @@
   background-color: rgba(206, 206, 206, 0.4);
   font-size: 1em !important;
 }
+
+.user-avatar-activity {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+}
+
+.activity-description {
+  font-size: 15px;
+}


### PR DESCRIPTION
# Description
- Change styling for dashboard page
- Add activity history for QnA (when user replies to a question)

<img width="1437" alt="Screenshot 2021-03-10 at 5 11 21 PM" src="https://user-images.githubusercontent.com/40416736/110605031-ac0bea80-81c3-11eb-8179-79684adb8b3e.png">

<img width="1440" alt="Screenshot 2021-03-10 at 4 34 21 PM" src="https://user-images.githubusercontent.com/40416736/110601336-ca6fe700-81bf-11eb-81e7-429fb5d36047.png">


Notion link: https://www.notion.so/Style-dashboard-and-add-activity-history-to-Overture-8a1e7f5043ac466386040f3c52e84a9a

## Remarks
- Overture Activity history currently only shows who replied to which question. Will have to see how to structure activity history with multiple products

# Testing
- Visually checked with design for styling
- Tested activity history created when user replies to a question
