### PR TITLE
Fix Timesheet categories import

### DIFF
--- a/app/jobs/create_events_job.rb
+++ b/app/jobs/create_events_job.rb
@@ -9,10 +9,10 @@ class CreateEventsJob < ApplicationJob
       @event = Event.new
       @event.company = user.company
       @department = user.department
-      @event.categories << Category.find_or_create_by(name: titleize_keep_uppercase(row[:client]), category_type: "client", department: @department) if row[:client].present?
-      @event.categories << Category.find_or_create_by(name: titleize_keep_uppercase(row[:service_line]), category_type: "service_line", department: @department) if row[:service_line].present?
-      @event.categories << Category.find_or_create_by(name: titleize_keep_uppercase(row[:project]), category_type: "project", department: @department) if row[:project].present?
-      @event.categories << Category.find_or_create_by(name: titleize_keep_uppercase(row[:task]), category_type: "task", department: @department) if row[:task].present?
+      @event.categories << Category.find_or_create_by(name: titleize_keep_uppercase(row[:client]), category_type: "client") {|c| c.update(department: @department)} if row[:client].present?
+      @event.categories << Category.find_or_create_by(name: titleize_keep_uppercase(row[:service_line]), category_type: "service_line") {|c| c.update(department: @department)} if row[:service_line].present?
+      @event.categories << Category.find_or_create_by(name: titleize_keep_uppercase(row[:project]), category_type: "project") {|c| c.update(department: @department)} if row[:project].present?
+      @event.categories << Category.find_or_create_by(name: titleize_keep_uppercase(row[:task]), category_type: "task") {|c| c.update(department: @department)} if row[:task].present?
       @event.start_time = row[:date]
       @event.number_of_hours = row[:hours]
       @event.save!


### PR DESCRIPTION
# Description

Previously via import excel, the system cannot find general categories and will create department categories with the names of general categories which results in duplicate categories in the dropdowns and wrongly assigned categories to events.

This is because find_or_create_by is looking for categories with department: current department.

What i changed:
Categories find or create by to query without department
Updates only newly created categories' department to current department

Notion link: https://www.notion.so/Fix-Timesheet-import-categories-7fe9ab109d434af7bca918e267a8e3c0

## Remarks

Have yet to finish cleaning up the database. (does not affect dashboarding as naming is the same, users can still pick from either of the duplicate categories. affects user experience)

# Testing

Able to import excel containing general categories without recreating them as department categories.
Able to import excel containing department categories (original function was not affected)
Able to export csv
