### PR TITLE
Increase uploaded file size limit to 20MB

### DIFF
--- a/app/webpacker/src/javascripts/dashboard/components/uppy.js
+++ b/app/webpacker/src/javascripts/dashboard/components/uppy.js
@@ -132,8 +132,8 @@ function setupUppy(element){
     // In case of typos
     logger: Uppy.debugLogger,
     restrictions: {
-      // 10MB max size
-      maxFileSize: 10 * 1024 * 1024,
+      // 20MB max size
+      maxFileSize: 20 * 1024 * 1024,
       maxNumberOfFiles: 100,
       minNumberOfFiles: null,
       // Only allow images or PDF


### PR DESCRIPTION
# Description
Sam asked for 20MB file size limit for multiple uploads

Notion link: https://www.notion.so/{unique-id}

## Remarks
- Nil

# Testing
- Tested with uploading 16mb file
