### PR TITLE
Fix embedded cap table and performance report overflow

### DIFF
--- a/app/views/overture/home/capitalization_table.html.slim
+++ b/app/views/overture/home/capitalization_table.html.slim
@@ -32,7 +32,8 @@
 - else
   = render 'overture/home/banners/investors/cap_table', type: "CAPITALIZATION TABLE"
 - if @company.cap_table_url.present?
-  iframe.pb-3.pr-3.pl-7 width="100%" height="100%" src=@company.cap_table_url frameborder="0" style="border:0" allowfullscreen=""
+  .responsive-inline-frame-inner
+    iframe.pb-3.pr-3.pl-7 src=@company.cap_table_url frameborder="0" style="border:0" allowfullscreen=""
 - else
   - if @company.startup?
     = render 'overture/home/empty_states/startups/cap_table', type: "capitalization table"

--- a/app/views/overture/home/financial_performance.html.slim
+++ b/app/views/overture/home/financial_performance.html.slim
@@ -11,7 +11,8 @@
 - else
   = render 'overture/home/banners/investors/cap_table', type: "PERFORMANCE REPORT"
 - if @company.report_url.present?
-  iframe.pb-3.pr-3.pl-7 width="100%" height="100%" src=@company.report_url frameborder="0" style="border:0" allowfullscreen=""
+  .responsive-inline-frame-inner
+    iframe.pb-3.pr-3.pl-7 src=@company.report_url frameborder="0" style="border:0" allowfullscreen=""
 - else
   - if @company.startup?
     = render 'overture/home/empty_states/startups/cap_table', type: "performance report"

--- a/app/webpacker/src/stylesheets/metronic/overture/home.scss
+++ b/app/webpacker/src/stylesheets/metronic/overture/home.scss
@@ -59,3 +59,21 @@
 .activity-description {
   font-size: 15px;
 }
+
+.responsive-inline-frame-inner {
+  width: 100%;
+  position: relative;
+  overflow: hidden;
+  padding-top: 56.25%;
+  height: 0;
+  margin: auto;
+  margin-top: 20px;
+}
+
+.responsive-inline-frame-inner iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
# Description

Previously, on the cap table and performance report page, the google reports overflow beyond the footer.
FIx by having a wrapper class outside the iframe, inspired from https://blog.redpillanalytics.com/responsive-google-data-studio-inline-frame-embed-code-37037b3f4a78

Notion link: https://www.notion.so/Fix-overture-footer-5f0e1cd04e394b7dbde7ea9978b52366

## Remarks

All is good for now

# Testing

Able to see reports and the reports dont overflow.
