### PR TITLE
Fix dashboard qna number

### DIFF
--- a/app/controllers/overture/home_controller.rb
+++ b/app/controllers/overture/home_controller.rb
@@ -7,10 +7,10 @@ class Overture::HomeController < ApplicationController
   after_action :verify_authorized, except: :index
 
   def index
-    @need_answer = Topic.where(company: @company, status: "need_answer")
-    @need_approval = Topic.where(company: @company, status: "need_approval")
-    @answered = Topic.where(company: @company, status: "answered")
-    @closed = Topic.where(company: @company, status: "closed")
+    @need_answer = Topic.where(startup: @company, status: "need_answer")
+    @need_approval = Topic.where(startup: @company, status: "need_approval")
+    @answered = Topic.where(startup: @company, status: "answered")
+    @closed = Topic.where(startup: @company, status: "closed")
     @activities = PublicActivity::Activity.includes(:owner, :recipient).order("created_at desc").where(trackable_type: "Note").where(recipient_type: "Company", recipient_id: @company.id)
     @posts = policy_scope(Post)
   end


### PR DESCRIPTION
# Description

Previously, the qna number in startup dashboard is wrong.
Changed the query from 'company' to 'startup'.

Notion link: https://www.notion.so/Dashboard-QnA-number-is-not-showing-real-number-932d379c0d614dd984037939f49eda3f

## Remarks

If we need the qna number in investor dashboard, we will need to condition  the controller to check whether @company is a startup or investor and query accordingly.

# Testing

Add new topics and numbers were reflected correctly.