### PR TITLE
dataroom documents table

### DIFF
--- a/app/views/overture/startups/documents/_dataroom.html.slim
+++ b/app/views/overture/startups/documents/_dataroom.html.slim
@@ -67,7 +67,7 @@ hr.m-0
           th.col style="min-width: 6%"
           - if current_user.has_role?(:admin, current_user.company)
             - @roles.each do |role|
-              th.col-1.dataroom-tour-3
+              th.col-1.dataroom-tour-3.text-break
                 a title="#{role.users.map(&:full_name).join("<br/>")}" data-html="true" data-placement="bottom" data-toggle="tooltip" data-trigger="hover" = role.name
       tbody.draggable-zone
         - @folders.each_with_index do |folder, index|


### PR DESCRIPTION
# Description

[first commit]
Dataroom documents table with no groups would not extend to fit the full screen. Have changed class of dropdown button from col-1 to col and added min-width styling to the the column to ensure that with zero, one or two groups, the table will still extend to the full screen width.

[second commit]
Table headers for groups will overlap if text is too long. Added class text-break.

Notion link: https://www.notion.so/Fix-ugly-documents-table-when-there-are-no-groups-29ac2c70ead444d1ac2f712fc9ccfa68

Solution with no groups now.
![image](https://user-images.githubusercontent.com/66553602/118598589-e0fa7600-b7e0-11eb-9dcf-d1e14228d070.png)

## Remarks

Note that without min-width style at the drop down button, it would overlap with the groupings (if there are many groups, e.g. 5 groups).

# Testing

Try with 4 options (1) no groups, (2) one group, (3) two groups and (4) 5 groups. Also try with zooming into the screen.