### PR TITLE
Fixed dataroom stacked icons when zoomed out

### DIFF
--- a/app/views/overture/startups/documents/_dataroom.html.slim
+++ b/app/views/overture/startups/documents/_dataroom.html.slim
@@ -67,7 +67,7 @@ hr.m-0
           th.col style="min-width: 6%"
           - if current_user.has_role?(:admin, current_user.company)
             - @roles.each do |role|
-              th.col.dataroom-tour-3.text-break style="min-width: 10%"
+              th.col.dataroom-tour-3.text-break style="min-width: 12%"
                 a title="#{role.users.map(&:full_name).join("<br/>")}" data-html="true" data-placement="bottom" data-toggle="tooltip" data-trigger="hover" = role.name
       tbody.draggable-zone
         - @folders.each_with_index do |folder, index|
@@ -94,7 +94,7 @@ hr.m-0
                     .dropdown-item = link_to "Activity History", "#", id: "drawer_toggle_#{folder.id}_0"
             - if current_user.has_role?(:admin, current_user.company)
               - @roles.each do |role|
-                td.col.dataroom-tour-2 style="min-width: 10%"
+                td.col.dataroom-tour-2 style="min-width: 12%"
                   = render "overture/documents/permissions_icons", role: role, permissible: folder, permissible_type: "folder"
           = render 'overture/shared/drawer', permissible: folder, permissible_type: 'folder', name: folder.name, url: overture_folders_path(id: folder.id, format: 'json'), file: folder, path: "overture/folders/", byte_size: Folder.last.descendants.select{|desc| desc.is_a?(Document)}.map{|doc| number_to_human_size(doc.raw_file.byte_size)}.reduce(0, :+)
         - @documents.each_with_index do |d, index|
@@ -123,7 +123,7 @@ hr.m-0
                     .dropdown-item = link_to "Download", d.versions.attached? ? rails_blob_path(d.versions.attachments.find_by(current_version: true), disposition: "attachment") : d.file_url
             - if current_user.has_role?(:admin, current_user.company)
               - @roles.each do |role|
-                td.col style="min-width: 10%"
+                td.col style="min-width: 12%"
                   = render "overture/documents/permissions_icons", role: role, permissible: d, permissible_type: "document"
             = render 'overture/shared/show_document', current_version_document: d.versions.attachments.find_by(current_version: true), d: d
             = render 'overture/documents/modals/version_control_modal', d: d


### PR DESCRIPTION
# Description

There will be stacked icons for the groups icon in dataroom when zoomed out or some screens at 100%. Have added min-width (12%) to the group icon columns instead of fixing each column width at col-1 so that the group icons will be in a row when zoomed out.

Notion link: https://www.notion.so/dataroom-stacked-group-icons-when-zoomed-in-98841e37f6db4077b70ceafe352ab8e0

## Remarks

Group icon columns are now set at min-width of 12%, which is slightly more than an estimate of 8% for the width of a col-1 width. 

# Testing

Check for the group icons on various zoom levels with different number of groups (0, 1, 2, 3 or more).