### PR TITLE
Updated flash message

### DIFF
--- a/app/controllers/overture/topics/notes_controller.rb
+++ b/app/controllers/overture/topics/notes_controller.rb
@@ -25,7 +25,7 @@ class Overture::Topics::NotesController < Overture::NotesController
           NotificationMailer.need_approval_notification(user, @topic, @note).deliver_later
         end
       end
-      redirect_to overture_topic_notes_path(topic_id: @topic.id), notice: "Answer has been posted. Please wait for answer to be approved."
+      redirect_to overture_topic_notes_path(topic_id: @topic.id), notice: "Answer has been posted."
     else
       render :new
     end


### PR DESCRIPTION
# Description

Removed the line of "Please wait for answer to be approved".

Notion link: https://www.notion.so/Flash-message-for-investor-should-not-be-wait-for-answer-to-be-approved-9f4961f4ae8c4fadb0083418c6d517a1

## Remarks

# Testing

To reproduce the notice and see if the change in the words will be reflected.