### PR TITLE
Default creation of folders for Shared Files and Resource Portal

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -29,6 +29,7 @@ class CompaniesController < ApplicationController
       elsif @company.products.include? "overture"
         set_default_profile_or_contact
         set_default_contact_statuses
+        set_default_overture_folders
       end
       current_user.update(company: @company)
       # Redirect based on the products that was added to the company
@@ -98,6 +99,17 @@ class CompaniesController < ApplicationController
     # Current user should have access permission to default folders
     motif_default_folders.each do |folder|
       # Create full access permission for franchisor
+      Permission.create(user_id: current_user.id, permissible: folder, can_write: true, can_view: true, can_download: true)
+    end
+  end
+
+  def set_default_overture_folders
+    # Create default folders with permissions when adding a new company
+    overture_default_folder_names = ["Resource Portal", "Shared Files"]
+    # Get all the new folder instances
+    overture_default_folders = overture_default_folder_names.map{|name| Folder.create(name: name, company: @company)}
+    overture_default_folders.each do |folder|
+      # Create full access permission for company created
       Permission.create(user_id: current_user.id, permissible: folder, can_write: true, can_view: true, can_download: true)
     end
   end


### PR DESCRIPTION
# Description
Previously "Shared files" & "Resource Portal" folders was the same as Dataroom. Now there will be a default folder created for both when creating a company in Overture.

Notion link: https://www.notion.so/Add-default-Shared-files-Resource-Portal-folders-when-creating-a-company-in-Overture-a5b17019082346eebf334389add032df

## Remarks

# Testing
Create a new start up company in overture and select "Shared files" & "Resource Portal" in the side bar to see if does not link back to Dataroom and has a folder by itself.