### PR TITLE
Fixed the contact information wrapper

### DIFF
--- a/app/views/overture/contacts/show.html.slim
+++ b/app/views/overture/contacts/show.html.slim
@@ -1,7 +1,7 @@
 = render 'contact_contents', contact: @contact
 .row
   / Only show contact sidebar if contact is cloned into fundraising board or contact is created in fundraising board (not link to any company in overture yet)
-  - if false
+  - if @contact.cloned_by_id.present? or @contact.company.nil?
     .col-sm-2.bg-white.sidebar-border-radius.ml-10
       = render 'contact_sidebar'
     .col-sm


### PR DESCRIPTION
# Description

Fixed the contact information wrapper where originally the margins were not placed in the correct place.

Notion link: https://www.notion.so/Fix-overture-contacts-page-information-wrapper-3009009e7e464322996bc3bffed9d20e

## Remarks

One thing to take note of is that there is no need to always have fixed columns of up to 12, we can have col-3 then the other col has no number to allow the second column to extend all the way.

# Testing

Test to see if the the words will extend out of the column now.