### PR TITLE
Fix document preview

### DIFF
--- a/app/views/overture/shared/_show_document.html.slim
+++ b/app/views/overture/shared/_show_document.html.slim
@@ -12,7 +12,7 @@
           - if current_version_document.content_type == "application/pdf"
             iframe src="#{url_for(current_version_document)}#toolbar=0" width="100%" height="1000" style="border: none;" class="pointer-event-none"
           / Images will be viewed using active storage preview
-          - elsif ['.jpg', '.jpeg', '.png', '.gif'].include? File.extname(d.raw_file.filename.to_s)
+          - elsif ['.jpg', '.jpeg', '.png', '.gif'].include? File.extname(current_version_document.filename.to_s.downcase)
             = image_tag(current_version_document, class: 'img-fluid pointer-event-none')
           - else
             = image_tag current_version_document.preview(resize_to_limit: [700, 700]), class: 'pointer-event-none' if current_version_document.previewable?


### PR DESCRIPTION
# Description

Previously, if versions of images were added, the image cannot be previewed as it cannot find the versions filename.
Also, if images have extensions in uppercase, the preview cannot be rendered as well.

Replaced raw_file with current_version_document
Standardise extname to lowercase

Notion link: https://www.notion.so/Dataroom-preview-broken-78f19c371ebf49a095d5158e182a0d0d

## Remarks

# Testing

Able to view newer versions of images
