### PR TITLE
Fixed disabled save button

### DIFF
--- a/app/views/overture/documents/modals/_version_control_modal.html.slim
+++ b/app/views/overture/documents/modals/_version_control_modal.html.slim
@@ -5,12 +5,12 @@
         h5.mb-5#versionControl.modal-title Version Control
         p To upload a new version, simply drag and drop the file here, or browse from your device.
         = form_for d, url: overture_startups_document_path(d), method: :put do |f|
-          .row
+          .row id="row1"
             .col-sm-12
               .form-group
                 .input-group.mb-3
                   .custom-file
-                    = f.file_field :versions, multiple: true, class: "custom-file-input", id: "version_control_valid_file"
+                    = f.file_field :versions, multiple: true, class: "custom-file-input"
                     label.custom-file-label Choose file
           .row
             .col-sm-12
@@ -35,4 +35,4 @@
                       = link_to overture_startups_delete_version_attachment_path(signed_id: attachment.blob.signed_id), method: :delete, data: { confirm: 'Current version is about to be permanently deleted. Delete forever?' } do
                         i.material-icons-outlined.align-middle.text-primary highlight_off
           .form-group
-            = f.submit "Save", class: "btn btn-primary float-right", disabled: true, id: "vc_submit_button"
+            = f.submit "Save", class: "btn btn-primary float-right", disabled: true

--- a/app/views/overture/startups/documents/_dataroom.html.slim
+++ b/app/views/overture/startups/documents/_dataroom.html.slim
@@ -69,6 +69,7 @@ hr.m-0
             - @roles.each do |role|
               th.col.dataroom-tour-3.text-break style="min-width: 12%"
                 a title="#{role.users.map(&:full_name).join("<br/>")}" data-html="true" data-placement="bottom" data-toggle="tooltip" data-trigger="hover" = role.name
+          th
       tbody.draggable-zone
         - @folders.each_with_index do |folder, index|
           tr.draggable.folders.drawer-row.d-flex id="#{folder.id}" data-drawer=folder.id data-permissible-type="folder"
@@ -96,6 +97,7 @@ hr.m-0
               - @roles.each do |role|
                 td.col.dataroom-tour-2 style="min-width: 12%"
                   = render "overture/documents/permissions_icons", role: role, permissible: folder, permissible_type: "folder"
+            td
           = render 'overture/shared/drawer', permissible: folder, permissible_type: 'folder', name: folder.name, url: overture_folders_path(id: folder.id, format: 'json'), file: folder, path: "overture/folders/", byte_size: Folder.last.descendants.select{|desc| desc.is_a?(Document)}.map{|doc| number_to_human_size(doc.raw_file.byte_size)}.reduce(0, :+)
         - @documents.each_with_index do |d, index|
           tr.drawer-row.draggable.d-flex id="#{d.id}" data-drawer="#{d.id}" data-permissible-type="document"
@@ -126,6 +128,7 @@ hr.m-0
                 td.col style="min-width: 12%"
                   = render "overture/documents/permissions_icons", role: role, permissible: d, permissible_type: "document"
             = render 'overture/shared/show_document', current_version_document: d.versions.attachments.find_by(current_version: true), d: d
-            = render 'overture/documents/modals/version_control_modal', d: d
+            td
+              = render 'overture/documents/modals/version_control_modal', d: d
           = render 'overture/shared/drawer', permissible: d, permissible_type: 'document', name: d.raw_file.filename, url: overture_startups_documents_path(id: d.id, format: 'json'), path: "overture/startups/documents/", byte_size: number_to_human_size(d.raw_file.byte_size) if d.raw_file.attached?
   = paginate @documents, views_prefix: 'dashboard'

--- a/app/views/overture/topics/index.html.slim
+++ b/app/views/overture/topics/index.html.slim
@@ -34,6 +34,6 @@
             a.btn.btn-icon.btn-link href="#" aria-expanded="false" aria-haspopup="true" data-toggle="dropdown"
               i.fa.fa-ellipsis-h.text-secondary.mb-4
             .dropdown-menu.dropdown-menu-right
-              .dropdown-item = link_to "Close question", overture_topic_path(topic, status: "closed"), method: :put , data: { confirm: 'By closing a question, you will no longer receive any answer. This action cannot be undone. Sure to proceed?' }
+              .dropdown-item = link_to "Close question", overture_topic_path(topic, status: "closed"), method: :put , data: { confirm: 'By closing a question, you will no longer receive an answer. This action cannot be undone. Sure to proceed?' }
     hr
         / = render 'overture/shared/topic_drawer', topic: topic, name: topic.subject_name

--- a/app/webpacker/src/javascripts/dashboard/overture/bulk_assignment.js
+++ b/app/webpacker/src/javascripts/dashboard/overture/bulk_assignment.js
@@ -50,7 +50,7 @@ $(document).on("turbolinks:load", function () {
   function showNumberOfCheckedBox(){
     count = $(".checkSingle:checked").length
     $("#selectedNumber")[0].innerHTML = count + " item(s) selected";
-    $("#deleteCount")[0].innerHTML = "You are going to delete " + count + " item(s). It can’t be undone. Confirm to delete?";
+    $("#deleteCount")[0].innerHTML = "Are you sure you would like to delete the selected " + count + " item(s)? This action cannot be undone.";
   }
 
   // Append hidden field on bulk delete and bulk assignment

--- a/app/webpacker/src/javascripts/dashboard/overture/version_control.js
+++ b/app/webpacker/src/javascripts/dashboard/overture/version_control.js
@@ -1,10 +1,8 @@
-$(document).on("turbolinks:load", function () {
-  $("#version_control_valid_file").change(function() {
-    if ($("#version_control_valid_file").val() != "") {
-      $("#vc_submit_button").attr("disabled", false);
-    }
-    else {
-      $("#vc_submit_button").attr("disabled", true);
+$(document).on("turbolinks:load", function () {  
+  $(".custom-file-input").change(function() {
+    submit_form_group = $(this).closest("#row1").siblings(".form-group").children();
+    if ($(this).val() != "") {
+      $(submit_form_group).attr("disabled", false);
     }
   });
 });


### PR DESCRIPTION
# Description

Reopened issue where only the first row of the save document would work with the version pop up. 
1. The JavaScript file did not call the id of the specific save button to enable previously. 
2. Subsequent files would not be saved

Also fixed a issue on the save button not being able to be clicked on when changing between items on the sidebar but not refreshing the page by adding a `td` to the rendering of the dataroom file, was previously fixed by Niu, reverted back to her fix. This issue is linked to https://github.com/paloesg/excide/pull/955/files.

Notion link: https://www.notion.so/dataroom-version-control-broken-page-when-clicked-save-but-files-added-af1598eb32304cb5addb42e45f6e7737

## Remarks

# Testing

Test the saving of documents in progressive amounts of documents added (1 file first, 2, 3...).

Also test the saving of documents and stopping midway by changing screens or pages to see if the save button should work normally when trying to upload file afterwards.