### PR TITLE
Document associated with franchisee

### DIFF
--- a/app/views/motif/documents/index.html.slim
+++ b/app/views/motif/documents/index.html.slim
@@ -98,7 +98,7 @@
         th
           input# type="checkbox" name=""/
         th.text-muted NAME
-        th.text-muted TAGS
+        th.text-muted COMPANY
         th.text-muted DATE MODIFIED
         th.text-muted ACCESS
         th
@@ -117,9 +117,10 @@
                 .badge.badge-secondary.ml-5 Shared
           td id="drawer_toggle_#{folder.id}_0"
             div id="tags_count_#{folder.id}"
-              = content_tag :span, folder.all_tags_list.first, class: ["badge badge-motif", folder.all_tags_list.length > 0 ? "" : "d-none"]
-              span class=(folder.all_tags_list.length > 1 ? "" : "d-none")
-                = (folder.all_tags_list.length-1).to_s + "+..."
+              = content_tag :span, folder.company.name, class: ["badge badge-motif"]
+              / = content_tag :span, folder.all_tags_list.first, class: ["badge badge-motif", folder.all_tags_list.length > 0 ? "" : "d-none"]
+              / span class=(folder.all_tags_list.length > 1 ? "" : "d-none")
+              /   = (folder.all_tags_list.length-1).to_s + "+..."
           td id="drawer_toggle_#{folder.id}_1"
             = folder.updated_at.strftime("%d %b %Y at %I:%M%p")
           td id="drawer_toggle_#{folder.id}_2"
@@ -152,9 +153,10 @@
                 .badge.badge-secondary.ml-5 Shared
           td id="drawer_toggle_#{d.id}_0"
             div id="tags_count_#{d.id}"
-              = content_tag :span, d.all_tags_list.first, class: ["badge badge-motif", d.all_tags_list.length > 0 ? "" : "d-none"]
-              span class=(d.all_tags_list.length > 1 ? "" : "d-none")
-                = (d.all_tags_list.length-1).to_s + "+..."
+              = content_tag :span, d.company.name, class: ["badge badge-motif"]
+              / = content_tag :span, d.all_tags_list.first, class: ["badge badge-motif", d.all_tags_list.length > 0 ? "" : "d-none"]
+              / span class=(d.all_tags_list.length > 1 ? "" : "d-none")
+              /   = (d.all_tags_list.length-1).to_s + "+..."
           td id="drawer_toggle_#{d.id}_1"
             = d.raw_file.attached? ? d.raw_file.created_at.strftime("%d %b %Y at %I:%M%p") : d.created_at.strftime("%d %b %Y at %I:%M%p")
           td id="drawer_toggle_#{d.id}_2"

--- a/app/views/motif/shared/_drawer.html.slim
+++ b/app/views/motif/shared/_drawer.html.slim
@@ -32,14 +32,15 @@
           .col
             span.text-muted Shared with
             p = pluralize(get_view_permission_count(permissible), 'other')
-        span.text-muted Tags
-        input.motif-tags.my-3 id="tag_#{permissible.id}" placeholder=" + Add tag" value=permissible.all_tags_list data-tag=permissible.id data-whitelist=@company.owned_tags.pluck(:name).join(", ") data-path=path
-        / Form for remarks document
+        // commented bottom two lines off as we changed from Tags to Company to show current company name
+        / span.text-muted Tags
+        / input.motif-tags.my-3 id="tag_#{permissible.id}" placeholder=" + Add tag" value=permissible.all_tags_list data-tag=permissible.id data-whitelist=@company.owned_tags.pluck(:name).join(", ") data-path=path
+        // Form for remarks document
         = form_for(permissible, url: url, method: :patch, remote: true) do |f|
           .col-md-12.p-0
             = f.label :remarks, "Remarks", class: 'text-muted'
             = f.text_field :remarks, { class: 'form-control remark-border p-0', data: { document_id: permissible.id, path: path }, onchange: "remarks(this);"}
-      / Only admin of company have access tab
+      // Only admin of company have access tab
       - if (current_user.has_role?(:admin, @company) or current_user.has_role?(:franchisor, @company))
         .tab-pane.fade.pt-3.pr-3.mr-n5.scroll.ps.px-5 id="access_#{permissible.id}" role="tabpanel"
           / .form-row.align-items-center.border-bottom
@@ -59,7 +60,7 @@
               .col-md-5.pl-0
                 - permission = user.permissions.find_by(permissible_id: permissible.id)
                 - if permission.present?
-                  / Permissible type passed in from rendering the partial, which will determine if permissible is folder or document
+                  // Permissible type passed in from rendering the partial, which will determine if permissible is folder or document
                   = select_tag 'permissions', options_for_select(["Can download", "Can write"], selected: (permission.can_write? ? "Can write" : "Can download")), include_blank: true, required: true, data: { user_id: user.id, permissible_id: permissible.id, permission_id: permission.id, permissible_type: permissible_type == "folder" ? "folder" : "document" },  class: 'form-control permission-document-access col-md-12'
                 - else
                   .float-right.mt-3.add-access id="add-access-link-#{user.id}-#{permissible.id}"


### PR DESCRIPTION
# Description

Tag was originally editable. Now the Tag has been changed to non-editable Company name based on the document (company_id field) uploaded. Folder will also show the respective 

Notion link: https://www.notion.so/Add-franchisee-association-to-each-document-3d85488714334bfabe518842ede14bc3

## Remarks

There is an empty franchisee_id field for each document in the database. Can look into making use of this field in the future.

Issues:
1. Franchisee should be able to see the documents uploaded by its outlet, however currently it is not able to.
2. Drawer history does not reflect updated history.

# Testing

Test by uploading documents as an outlet and as a franchisee (area, master and unit) to see if the relevant parties (usually the franchisor/master franchisee one level above) should be able to see the documents uploaded.