### PR TITLE
Add word-break to file names

### DIFF
--- a/app/views/motif/workflows/_task.html.slim
+++ b/app/views/motif/workflows/_task.html.slim
@@ -59,8 +59,8 @@
   - @documents.where(workflow_action_id: wfa.id).each do |d|
     .row.my-5
       / File Name
-      .col-md-10
-        .wb = d.raw_file.filename
+      .col-md-10.text-break
+        = d.raw_file.filename
       .col-md-2
         .dropdown
           a.btn.btn-icon.btn-link href="#" aria-expanded="false" aria-haspopup="true" data-toggle="dropdown"

--- a/app/webpacker/src/stylesheets/metronic/css/layout.scss
+++ b/app/webpacker/src/stylesheets/metronic/css/layout.scss
@@ -188,6 +188,3 @@ a.custom-card:hover {
   vertical-align: super;
   font-size: 8px;
 }
-.wb {
-  word-break: break-all;
-}


### PR DESCRIPTION
# Description

Add word-break to files uploaded in ADA.
 

Notion link: https://www.notion.so/ADA-uploaded-files-work-break-93a4d36f960e4196a0a5dd49eb9a4452

## Remarks

[Are there any issues to take note of? For example, anything that might cause problems or any code that can be refactored in the future.]

# Testing

Go to Onboarding management page click on existing existing outlet.
Select a task and upload a file with very long name
