### PR TITLE
Add slack notification to inform new company signed up

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -35,7 +35,7 @@ class CompaniesController < ApplicationController
       end
       current_user.update(company: @company)
       # Send Slack Notification when new company is created
-      SlackService.new.company_signup(current_user, current_user.company).deliver
+      SlackService.new.company_signup(current_user.company).deliver
       # Redirect based on the products that was added to the company
       if @company.products.length > 1
         redirect_to root_path

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -37,7 +37,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
       end
       resource.save
       # Send Slack Notification when new company is created
-      SlackService.new.company_signup(resource, resource.company).deliver
+      SlackService.new.company_signup(resource.company).deliver
     end
     # end
     # Add default roles to company

--- a/app/services/slack_service.rb
+++ b/app/services/slack_service.rb
@@ -61,7 +61,7 @@ class SlackService
     self
   end
 
-  def company_signup(user, company)
+  def company_signup(company)
     params = {
       attachments: [
         {


### PR DESCRIPTION
# Description
 Add back slack notification to inform Paloe that a company has signed up for Overture
- 2 scenarios of signing up: Paloe add through superadmin company NEW page & overture sign up page

Notion link: https://www.notion.so/Add-Slack-notification-when-user-first-sign-up-with-Overture-edbb9dfc1b784c47ab30fc2b3df33a4b

## Remarks
- Nil

# Testing
- Tested the 2 scenarios stated above. Both send out a slack notification informing us of company signing up
