### PR TITLE
Bugfix 20210906 

### DIFF
--- a/app/controllers/overture/folders_controller.rb
+++ b/app/controllers/overture/folders_controller.rb
@@ -23,7 +23,7 @@ class Overture::FoldersController < FoldersController
   def show
     authorize @folder
     @users = @company.users.includes(:permissions)
-    @folders = Folder.children_of(@folder)
+    @folders = @company.startup? ? Folder.children_of(@folder) : Folder.children_of(@folder).includes(:permissions).where(company: @folder.company, permissions: { can_view: true, role_id: @user.roles.map(&:id)}).where.not(name: ["Resource Portal", "Shared Files"])
     # Query for breadcrumb folder arrangement
     @breadcrumb_folder_arrangement = @folder.path.order(:created_at)
     @activities = PublicActivity::Activity.order("created_at desc").where(trackable_type: "Document").first(10)


### PR DESCRIPTION
# Description

Previously, when folders are nested within a folder, the investor can still see the folder despite permissions being removed.
Fix query regarding seeing the nested folder where permission is true

Notion link: https://www.notion.so/{unique-id}

## Remarks

[Are there any issues to take note of? For example, anything that might cause problems or any code that can be refactored in the future.]

# Testing

[Please describe the tests that you used to verify your changes. Provide instructions so that the tests can be reproduced.]
