### PR TITLE
Allow uploading of folders into dataroom

### DIFF
--- a/app/webpacker/src/javascripts/dashboard/components/uppy.js
+++ b/app/webpacker/src/javascripts/dashboard/components/uppy.js
@@ -163,7 +163,8 @@ function setupUppy(element){
     thumbnailWidth: 280,
     metaFields: [
       { id: 'name', name: 'Name', placeholder: 'file name' }
-    ]
+    ],
+    fileManagerSelectionType: 'both'
   });
 
   if($('.batchUploads').length){


### PR DESCRIPTION
# Description

Allow uploading of folders via uppy dashboards

Notion link: https://www.notion.so/{unique-id}

## Remarks

Will need to consider creating folders via the system, currently it only creates all the files within the folder.

# Testing

Upload a folder and check that all the files are uploaded
