### PR TITLE
Use ajax for permissions in dataroom

### DIFF
--- a/app/controllers/overture/permissions_controller.rb
+++ b/app/controllers/overture/permissions_controller.rb
@@ -17,9 +17,9 @@ class Overture::PermissionsController < ApplicationController
     end
     # Depending on permissible_type, get the instance of the respective permissible (document or folder)
     @permissible = params[:permissible_type] == "folder" ? Folder.find(params[:permissible_id]) : Document.find(params[:permissible_id])
-    CreatePermissionsJob.perform_later(Role.find(params[:role_id]), @permissible, permission_changes['status'][:can_view], permission_changes['status'][:can_download], permission_changes['status'][:can_write])
+    CreatePermissionsJob.perform_now(Role.find(params[:role_id]), @permissible, permission_changes['status'][:can_view], permission_changes['status'][:can_download], permission_changes['status'][:can_write])
     respond_to do |format|
-        format.json { render json: { link_to: session[:previous_url], status: "ok" } }
+        format.json { render json: { permissions: permission_changes['status'], permission_id: Permission.find_by(permissible: @permissible, role_id: params[:role_id]).id, status: "ok" } }
     end
   end
 
@@ -40,7 +40,7 @@ class Overture::PermissionsController < ApplicationController
     UpdatePermissionsJob.perform_later(Role.find(params[:role_id]), @permission, permission_changes['status'][:can_view], permission_changes['status'][:can_download], permission_changes['status'][:can_write])
     respond_to do |format|
       if @permission.update(can_view: permission_changes['status'][:can_view], can_download: permission_changes['status'][:can_download], can_write: permission_changes['status'][:can_write])
-        format.json { render json: { link_to: session[:previous_url], status: "ok" } }
+        format.json { render json: { permissions: permission_changes['status'], status: "ok" } }
       else
         format.json { render json: @permission.errors, status: :unprocessable_entity }
       end

--- a/app/webpacker/src/javascripts/dashboard/overture/access_control.js
+++ b/app/webpacker/src/javascripts/dashboard/overture/access_control.js
@@ -1,5 +1,6 @@
 $(document).on("turbolinks:load", function () {
   $(".permission-icon").click(function(){
+    const icons = $(this).parent().find(".permission-icon");
     // Check if permission exists, if it does, then update the permission. Else, create the permission.
     if ($(this).data("permission-id")){
       $.ajax({
@@ -11,8 +12,30 @@ $(document).on("turbolinks:load", function () {
         },
         dataType: "JSON"
       }).done(function(result) {
-        const linkTo = result["link_to"];
-        Turbolinks.visit(linkTo);
+        icons.each(function() {
+          // Change the css of the permission icons and tooltip description
+          if (result["permissions"][`can_${$(this).data("status")}`]) {
+            $(this).find("i").removeClass("text-muted");
+            $(this).find("i").addClass("icon-hover");
+            if ($(this).data("status") == "view") {
+              $(this).attr("data-original-title", "Disable view &<br/>download access");
+            } else if ($(this).data("status") == "download") {
+              $(this).attr("data-original-title", "Disable download access");
+            } else {
+              $(this).attr("data-original-title", "Disable full access");
+            }
+          } else {
+            $(this).find("i").addClass("text-muted");
+            $(this).find("i").removeClass("icon-hover");
+            if ($(this).data("status") == "view") {
+              $(this).attr("data-original-title", "Give view access");
+            } else if ($(this).data("status") == "download") {
+              $(this).attr("data-original-title", "Give view &<br/>download access");
+            } else {
+              $(this).attr("data-original-title", "Give full access");
+            }
+          }
+        });
       });
     }
     else{
@@ -23,8 +46,32 @@ $(document).on("turbolinks:load", function () {
         permissible_id: $(this).data("permissible-id"),
         permissible_type: $(this).data("permissible-type"),
       }).done(function(result){
-        const linkTo = result["link_to"];
-        Turbolinks.visit(linkTo);
+        // Change the css of the permission icons and tooltip description
+        icons.each(function() {
+          // Attach data-permission-id so that the icon triggers update method next time
+          $(this).attr("data-permission-id", result["permission_id"]);
+          if (result["permissions"][`can_${$(this).data("status")}`]) {
+            $(this).find("i").removeClass("text-muted");
+            $(this).find("i").addClass("icon-hover");
+            if ($(this).data("status") == "view") {
+              $(this).attr("data-original-title", "Disable view &<br/>download access");
+            } else if ($(this).data("status") == "download") {
+              $(this).attr("data-original-title", "Disable download access");
+            } else {
+              $(this).attr("data-original-title", "Disable full access");
+            }
+          } else {
+            $(this).find("i").addClass("text-muted");
+            $(this).find("i").removeClass("icon-hover");
+            if ($(this).data("status") == "view") {
+              $(this).attr("data-original-title", "Give view access");
+            } else if ($(this).data("status") == "download") {
+              $(this).attr("data-original-title", "Give view &<br/>download access");
+            } else {
+              $(this).attr("data-original-title", "Give full access");
+            }
+          }
+        });
       });
     }
   })


### PR DESCRIPTION
# Description

Instead of reloading the page, permissions are updated and frontend (eg colour, tooltip description) changes accordingly.

Notion link: https://www.notion.so/{unique-id}

## Remarks

Changed CreatePermissionsJob to be perform_now so that I can find the permission id and return it to the js.

# Testing

Able to update/create permissions in dataroom and frontend changes.
