### PR TITLE
Allow pdf preview scrolling

### DIFF
--- a/app/views/overture/shared/_show_document.html.slim
+++ b/app/views/overture/shared/_show_document.html.slim
@@ -10,7 +10,7 @@
         - if d.versions.attached?
           / If PDF, then view document in iframe
           - if current_version_document.content_type == "application/pdf"
-            iframe src="#{url_for(current_version_document)}#toolbar=0" width="100%" height="1000" style="border: none;" class="pointer-event-none"
+            iframe src="#{url_for(current_version_document)}#toolbar=0" width="100%" height="1000" style="border: none;"
           / Images will be viewed using active storage preview
           - elsif ['.jpg', '.jpeg', '.png', '.gif'].include? File.extname(current_version_document.filename.to_s.downcase)
             = image_tag(current_version_document, class: 'img-fluid pointer-event-none')


### PR DESCRIPTION
# Description

Remove pointer-events-none to allow users to scroll and view all pages in pdf preview.

Notion link: https://www.notion.so/{unique-id}

## Remarks

User can still right click to save the pdf, which means a user with the view permission can actually download the pdf.
Have yet to create previews for microsoft doc, excel.

# Testing

Can preview all pages of pdf.